### PR TITLE
Use new view registry API

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -10,9 +10,8 @@ Notifications =
 
     @subscriptions = new CompositeDisposable
 
-    atom.views.addViewProvider
-      modelConstructor: Notification
-      viewConstructor: NotificationElement
+    atom.views.addViewProvider Notification, (model) ->
+      new NotificationElement().initialize(model)
 
     @notificationsElement = new NotificationsElement
     atom.views.getView(atom.workspace).appendChild(@notificationsElement)

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -11,10 +11,12 @@ class NotificationElement extends HTMLElement
 
   constructor: ->
 
-  getModel: -> @model
-  setModel: (@model) ->
+  initialize: (@model) ->
     @generateMarkup()
     @autohide() unless @model.isClosable()
+    this
+
+  getModel: -> @model
 
   generateMarkup: ->
     @classList.add "#{@model.getType()}"


### PR DESCRIPTION
This fixes some new deprecation warnings. Also gave NotificationElement an `::initialize` method so you can instantiate one with a model in a single line.
