### PR TITLE
Better deal with closed issues and out of date packages

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -110,15 +110,15 @@ class NotificationElement extends HTMLElement
       async.parallel
         issue: (callback) =>
           @issue.fetchIssue (issue) => callback(null, issue)
-        shortUrl: (callback) =>
-          @issue.getShortUrl (url) -> callback(null, url)
+        systemUrl: (callback) =>
+          @issue.getIssueUrlForSystem (url) -> callback(null, url)
       , (err, result) ->
         if result.issue?
           issueButton.setAttribute('href', result.issue.html_url)
           issueButton.textContent = "View Issue"
           fatalNotification.textContent += " This issue has already been reported."
         else
-          issueButton.setAttribute('href', result.shortUrl) if result.shortUrl?
+          issueButton.setAttribute('href', result.systemUrl) if result.systemUrl?
           fatalNotification.textContent += " You can help by creating an issue. Please explain what actions triggered this error."
 
   removeNotification: ->

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -23,7 +23,7 @@ NotificationTemplate = """
 FatalMetaNotificationTemplate = """
   <div class="fatal-notification"></div>
   <div class="btn-toolbar">
-    <a href="#" class="btn btn-error"></a>
+    <a href="#" class="btn-issue btn btn-error"></a>
   </div>
 """
 
@@ -90,7 +90,7 @@ class NotificationElement extends HTMLElement
     fatalContainer.appendChild(TemplateHelper.render(@fatalTemplate))
     fatalNotification = @querySelector('.fatal-notification')
 
-    issueButton = fatalContainer.querySelector('.btn')
+    issueButton = fatalContainer.querySelector('.btn-issue')
 
     if packageName? and repoUrl?
       fatalNotification.innerHTML = "The error was thrown from the <a href=\"#{repoUrl}\">#{packageName} package</a>. "
@@ -109,18 +109,19 @@ class NotificationElement extends HTMLElement
         issueButton.textContent = "Create issue on atom/atom"
 
       promises = []
-      promises.push @issue.findSimilarIssue()
+      promises.push @issue.findSimilarIssues()
       promises.push @issue.getIssueUrlForSystem()
       promises.push UserUtilities.checkPackageUpToDate(packageName) if packageName?
 
       Promise.all(promises).then (allData) ->
-        [issue, newIssueUrl, packageCheck] = allData
+        [issues, newIssueUrl, packageCheck] = allData
 
-        if issue?
+        if issues?.open or issues?.closed
+          issue = issues.open or issues.closed
           issueButton.setAttribute('href', issue.html_url)
           issueButton.textContent = "View Issue"
           fatalNotification.textContent += " This issue has already been reported."
-        else if packageCheck? and !packageCheck.upToDate and !packageCheck.isCore
+        else if packageCheck? and not packageCheck.upToDate and not packageCheck.isCore
           issueButton.setAttribute('href', '#')
           issueButton.textContent = "Check for package updates"
           issueButton.addEventListener 'click', (e) ->

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -24,6 +24,7 @@ FatalMetaNotificationTemplate = """
   <div class="fatal-notification"></div>
   <div class="btn-toolbar">
     <a href="#" class="btn-issue btn btn-error"></a>
+    <a href="#" class="btn-copy-report icon icon-clippy" title="Copy error report to clipboard"></a>
   </div>
 """
 
@@ -91,6 +92,12 @@ class NotificationElement extends HTMLElement
     fatalNotification = @querySelector('.fatal-notification')
 
     issueButton = fatalContainer.querySelector('.btn-issue')
+
+    copyReportButton = fatalContainer.querySelector('.btn-copy-report')
+    atom.tooltips.add(copyReportButton, title: copyReportButton.getAttribute('title'))
+    copyReportButton.addEventListener 'click', (e) =>
+      e.preventDefault()
+      atom.clipboard.write(@issue.getIssueBody())
 
     if packageName? and repoUrl?
       fatalNotification.innerHTML = "The error was thrown from the <a href=\"#{repoUrl}\">#{packageName} package</a>. "

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -114,13 +114,13 @@ class NotificationElement extends HTMLElement
       promises.push UserUtilities.checkPackageUpToDate(packageName) if packageName?
 
       Promise.all(promises).then (allData) ->
-        [issue, newIssueUrl, latestPackage] = allData
+        [issue, newIssueUrl, packageCheck] = allData
 
         if issue?
           issueButton.setAttribute('href', issue.html_url)
           issueButton.textContent = "View Issue"
           fatalNotification.textContent += " This issue has already been reported."
-        else if latestPackage? and !latestPackage.upToDate and !latestPackage.isCore
+        else if packageCheck? and !packageCheck.upToDate and !packageCheck.isCore
           issueButton.setAttribute('href', '#')
           issueButton.textContent = "Check for package updates"
           issueButton.addEventListener 'click', (e) ->
@@ -129,8 +129,8 @@ class NotificationElement extends HTMLElement
             atom.commands.dispatch(atom.views.getView(atom.workspace), command)
 
           fatalNotification.textContent += """
-            #{packageName} is out of date: #{latestPackage.installedVersion} installed;
-            #{latestPackage.latestVersion} latest.
+            #{packageName} is out of date: #{packageCheck.installedVersion} installed;
+            #{packageCheck.latestVersion} latest.
             Upgrading to the latest version may fix this issue.
           """
         else

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -10,12 +10,12 @@ module.exports =
 class NotificationIssue
   constructor: (@notification) ->
 
-  findSimilarIssue: ->
+  findSimilarIssues: ->
     url = "https://api.github.com/search/issues"
     repoUrl = @getRepoUrl()
     repoUrl = 'atom/atom' unless repoUrl?
     repo = repoUrl.replace /http(s)?:\/\/(\d+\.)?github.com\//gi, ''
-    query = "#{@getIssueTitle()} repo:#{repo} state:open"
+    query = "#{@getIssueTitle()} repo:#{repo}"
 
     new Promise (resolve, reject) =>
       $.ajax "#{url}?q=#{encodeURI(query)}&sort=created",
@@ -23,8 +23,11 @@ class NotificationIssue
         contentType: "application/json"
         success: (data) =>
           if data.items?
+            issues = {}
             for issue in data.items
-              return resolve(issue) if issue.title.indexOf(@getIssueTitle()) > -1
+              issues[issue.state] = issue if issue.title.indexOf(@getIssueTitle()) > -1 and not issues[issue.state]?
+            return resolve(issues) if issues.open? or issues.closed?
+
           resolve(null)
         error: ->
           resolve(null)

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -27,10 +27,8 @@ class NotificationIssue
             for issue in data.items
               issues[issue.state] = issue if issue.title.indexOf(@getIssueTitle()) > -1 and not issues[issue.state]?
             return resolve(issues) if issues.open? or issues.closed?
-
           resolve(null)
-        error: ->
-          resolve(null)
+        error: (e) -> reject(e)
 
   getIssueUrlForSystem: ->
     new Promise (resolve, reject) =>

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -28,14 +28,18 @@ class NotificationIssue
       error: ->
         callback(null)
 
-  getShortUrl: (callback) ->
-    $.ajax 'http://git.io',
-      type: 'POST'
-      data: url: @getIssueUrl()
-      success: (data, status, xhr) ->
-        callback(xhr.getResponseHeader('Location'))
-      error: ->
-        callback(null)
+  getIssueUrlForSystem: (callback) ->
+    if UserUtilities.getPlatform() is 'win32'
+      # win32 can only handle a 2048 length link, so we use the shortener.
+      $.ajax 'http://git.io',
+        type: 'POST'
+        data: url: @getIssueUrl()
+        success: (data, status, xhr) ->
+          callback(xhr.getResponseHeader('Location'))
+        error: ->
+          callback(null)
+    else
+      callback(@getIssueUrl())
 
   getIssueUrl: ->
     repoUrl = @getRepoUrl()

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -141,8 +141,7 @@ class NotificationIssue
     return
 
   getPackagePathsByPackageName: ->
-    return @packagePathsByPackageName if @packagePathsByPackageName?
-    @packagePathsByPackageName = {}
+    packagePathsByPackageName = {}
     for pack in atom.packages.getLoadedPackages()
-      @packagePathsByPackageName[pack.name] = pack.path
-    @packagePathsByPackageName
+      packagePathsByPackageName[pack.name] = pack.path
+    packagePathsByPackageName

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -1,6 +1,8 @@
+$ = require 'jquery'
 os = require 'os'
 fs = require 'fs'
 plist = require 'plist'
+semver = require 'semver'
 {spawnSync} = require 'child_process'
 
 ###
@@ -66,3 +68,24 @@ module.exports =
 
   filterActivePackages: (packages) ->
     "#{pack.name}, v#{pack.version}" for pack in (packages ? []) when atom.packages.getActivePackage(pack.name)?
+
+  getPackageVersion: (packageName) ->
+    pack = atom.packages.getLoadedPackage(packageName)
+    pack.metadata.version
+
+  getLatestPackageData: (packageName) ->
+    packagesUrl = 'https://atom.io/api/packages'
+    new Promise (resolve, reject) ->
+      $.ajax "#{packagesUrl}/#{packageName}",
+        accept: 'application/vnd.github.v3+json'
+        contentType: "application/json"
+        success: (data) -> resolve(data)
+        error: (error) -> reject(error)
+
+  checkPackageUpToDate: (packageName) ->
+    @getLatestPackageData(packageName).then (latestPackageData) =>
+      installedVersion = @getPackageVersion(packageName)
+      upToDate = semver.gte(installedVersion, latestPackageData.releases.latest)
+      latestVersion = latestPackageData.releases.latest
+      isCore = latestPackageData.repository.url.startsWith('https://github.com/atom/')
+      { isCore, upToDate, latestVersion, installedVersion }

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -14,9 +14,12 @@ module.exports =
   Section: System Information
   ###
 
+  getPlatform: ->
+    os.platform()
+
   # OS version strings lifted from https://github.com/lee-dohm/bug-report
   getOSVersion: ->
-    switch os.platform()
+    switch @getPlatform()
       when 'darwin' then @macVersionText()
       when 'win32' then @winVersionText()
       else "#{os.platform()} #{os.release()}"
@@ -33,7 +36,7 @@ module.exports =
       {}
 
   winVersionText: ->
-    info = spawnSync('systeminfo').stdout.toString()
+    info = spawnSync('systeminfo').stdout?.toString() ? ''
     if (res = /OS.Name.\s+(.*)$/im.exec(info)) then res[1] else 'Unknown Windows Version'
 
   ###

--- a/package.json
+++ b/package.json
@@ -9,11 +9,11 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
-    "async": "^0.9.0",
     "jquery": "^2",
     "marked": "^0.3",
     "moment": "^2.8.4",
     "plist": "^1.1.0",
+    "semver": "^4.2.0",
     "stacktrace-parser": "0.1.1"
   }
 }

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -183,6 +183,10 @@ atom-notification {
   .btn-toolbar {
     margin-top:  @component-padding;
   }
+
+  .btn-copy-report {
+    vertical-align: middle;
+  }
 }
 
 // Types -------------------------------


### PR DESCRIPTION
Basically 

* [x] When there is an error on an out-of-date non-core package, it prompts the user to upgrade the package instead of prompting them to create an issue.
* [x] When there is a closed issue matching the title, show the view issue button
* [x] Add a `copy error report` icon button next to the view issue button so people can still get the error report if they want.