### PR TITLE
Remove atom/core team @-mention

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -71,7 +71,6 @@ class NotificationIssue
         packageVersion = atom.packages.getLoadedPackage(packageName)?.metadata?.version if packageName?
         userConfig = UserUtilities.getConfigForPackage(packageName)
         copyText = ''
-        copyText = '/cc @atom/core' if packageName? and repoUrl?
 
         if packageName? and repoUrl?
           packageMessage = "[#{packageName}](#{repoUrl}) package, v#{packageVersion}"

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -185,7 +185,6 @@ describe "Notifications", ->
             expect(issueBody).not.toMatch /Unknown/ig
             expect(issueBody).toContain 'ReferenceError: a is not defined'
             expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package, v'
-            expect(issueBody).toContain 'cc @atom/core'
             expect(issueBody).toContain '# User'
 
             # FIXME: this doesnt work on the test server. `apm ls` is not working for some reason.
@@ -234,7 +233,6 @@ describe "Notifications", ->
 
           expect(issueBody).toContain 'ReferenceError: a is not defined'
           expect(issueBody).toContain '**Thrown From**: Atom Core'
-          expect(issueBody).not.toContain 'cc @atom/core'
 
         it "contains core and editor config values", ->
           expect(issueBody).toContain '"core":'


### PR DESCRIPTION
Fixes https://github.com/atom/notifications/issues/27.

The @-mention of the atom/core team doesn't work because those work only when you're a member of that team and only when the repository in which the issue is created is in the atom organization.

cc @benogle @50Wliu