### PR TITLE
Restore focus after dismissing notification

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -159,6 +159,7 @@ class NotificationElement extends HTMLElement
   removeNotification: ->
     @classList.add('remove')
     @removeNotificationAfterTimeout()
+    atom.workspace.getActivePane().activate()
 
   handleRemoveNotificationClick: ->
     @model.dismiss()

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -92,18 +92,27 @@ describe "Notifications", ->
         expect(notificationContainer.childNodes.length).toBe 0
 
       it "is removed when the close icon is clicked", ->
-        notification = atom.notifications.addSuccess('A message', dismissable: true)
-        notificationElement = notificationContainer.querySelector('atom-notification.success')
+        jasmine.attachToDOM(workspaceElement)
 
-        expect(notificationContainer.childNodes.length).toBe 1
+        waitsForPromise ->
+          atom.workspace.open()
 
-        notificationElement.querySelector('.close.icon').click()
+        runs ->
+          notification = atom.notifications.addSuccess('A message', dismissable: true)
+          notificationElement = notificationContainer.querySelector('atom-notification.success')
 
-        advanceClock(NotificationElement::visibilityDuration)
-        expect(notificationElement).toHaveClass 'remove'
+          expect(notificationContainer.childNodes.length).toBe 1
 
-        advanceClock(NotificationElement::animationDuration)
-        expect(notificationContainer.childNodes.length).toBe 0
+          notificationElement.focus()
+          notificationElement.querySelector('.close.icon').click()
+
+          expect(atom.views.getView(atom.workspace.getActiveTextEditor())).toHaveFocus()
+
+          advanceClock(NotificationElement::visibilityDuration)
+          expect(notificationElement).toHaveClass 'remove'
+
+          advanceClock(NotificationElement::animationDuration)
+          expect(notificationContainer.childNodes.length).toBe 0
 
     describe "when an autoclose notification is added", ->
       it "closes and removes the message after a given amount of time", ->


### PR DESCRIPTION
Fixes https://github.com/atom/notifications/issues/34.

Inspired by how this is handled in [the dialogs from the Tree View package](https://github.com/atom/tree-view/blob/13fcdf24b1d66f6a7ab3f7c0fb2a4b30f27e9056/lib/dialog.coffee#L40). This restores focus correctly, but I failed at writing tests for this :crying_cat_face:. If we need them, I'd welcome the schooling.

cc @benogle @kevinsawicki