### PR TITLE
Push top-level require() calls down into the functions that use them.

### DIFF
--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -1,7 +1,7 @@
 # Originally from lee-dohm/bug-report
 # https://github.com/lee-dohm/bug-report/blob/master/lib/command-logger.coffee
 
-moment = require 'moment'
+moment = null
 
 # Command names that are ignored and not included in the log. This uses an Object to provide fast
 # string matching.
@@ -162,6 +162,7 @@ class CommandLogger
   #
   # Returns the {String} format of the command time.
   formatTime: (time) ->
+    moment ?= require 'moment'
     moment(time).format(@dateFmt)
 
   # Private: Initializes the log structure for speed.

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -1,5 +1,4 @@
 {Notification, CompositeDisposable} = require 'atom'
-CommandLogger = require './command-logger'
 
 Notifications =
   isInitialized: false
@@ -13,6 +12,7 @@ Notifications =
       default: false
 
   activate: (state) ->
+    CommandLogger = require './command-logger'
     CommandLogger.start()
     @subscriptions = new CompositeDisposable
 


### PR DESCRIPTION
Previous to this diff, I saw:

* `atom.packages.getLoadedPackage('notifications').loadTime` 8
* `atom.packages.getLoadedPackage('notifications').activateTime` 1

After this diff, I saw:

* `atom.packages.getLoadedPackage('notifications').loadTime` 1
* `atom.packages.getLoadedPackage('notifications').activateTime` 2