### PR TITLE
Dismiss with core cancel

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,8 +39,8 @@ Notifications =
           stack: originalError.stack
           dismissable: true
         atom.notifications.addFatalError(message, options)
-        
-    @subscriptions.add atom.commands.add 'core:cancel': ->
+
+    @subscriptions.add atom.commands.add 'atom-workspace', 'core:cancel', ->
       notification.dismiss() for notification in atom.notifications.getNotifications()
 
   deactivate: ->

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -39,6 +39,10 @@ Notifications =
           stack: originalError.stack
           dismissable: true
         atom.notifications.addFatalError(message, options)
+        
+      @subscriptions.add atom.commands.add 'core:cancel': ->
+        atom.notifications.getNotifications().forEach (notification) ->
+          notification.dismiss()
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -41,8 +41,7 @@ Notifications =
         atom.notifications.addFatalError(message, options)
         
     @subscriptions.add atom.commands.add 'core:cancel': ->
-      atom.notifications.getNotifications().forEach (notification) ->
-        notification.dismiss()
+      notification.dismiss() for notification in atom.notifications.getNotifications()
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,9 +40,9 @@ Notifications =
           dismissable: true
         atom.notifications.addFatalError(message, options)
         
-      @subscriptions.add atom.commands.add 'core:cancel': ->
-        atom.notifications.getNotifications().forEach (notification) ->
-          notification.dismiss()
+    @subscriptions.add atom.commands.add 'core:cancel': ->
+      atom.notifications.getNotifications().forEach (notification) ->
+        notification.dismiss()
 
   deactivate: ->
     @subscriptions.dispose()

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -114,6 +114,20 @@ describe "Notifications", ->
           advanceClock(NotificationElement::animationDuration)
           expect(notificationContainer.childNodes.length).toBe 0
 
+      it "is removed when core:cancel is triggered", ->
+        notification = atom.notifications.addSuccess('A message', dismissable: true)
+        notificationElement = notificationContainer.querySelector('atom-notification.success')
+
+        expect(notificationContainer.childNodes.length).toBe 1
+
+        atom.commands.dispatch(workspaceElement, 'core:cancel')
+
+        advanceClock(NotificationElement::visibilityDuration * 3)
+        expect(notificationElement).toHaveClass 'remove'
+
+        advanceClock(NotificationElement::animationDuration * 3)
+        expect(notificationContainer.childNodes.length).toBe 0
+
     describe "when an autoclose notification is added", ->
       it "closes and removes the message after a given amount of time", ->
         atom.notifications.addSuccess('A message')


### PR DESCRIPTION
Listen to core:cancel on atom-workspace. When triggered dismiss notifications.

Moved here from atom/atom#5972