### PR TITLE
Require up-to-date Atom version in order to create issues

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -126,10 +126,11 @@ class NotificationElement extends HTMLElement
       promises = []
       promises.push @issue.findSimilarIssues()
       promises.push @issue.getIssueUrlForSystem()
+      promises.push UserUtilities.checkAtomUpToDate()
       promises.push UserUtilities.checkPackageUpToDate(packageName) if packageName?
 
       Promise.all(promises).then (allData) =>
-        [issues, newIssueUrl, packageCheck] = allData
+        [issues, newIssueUrl, atomCheck, packageCheck] = allData
 
         if issues?.open or issues?.closed
           issue = issues.open or issues.closed
@@ -148,6 +149,14 @@ class NotificationElement extends HTMLElement
             #{packageName} is out of date: #{packageCheck.installedVersion} installed;
             #{packageCheck.latestVersion} latest.
             Upgrading to the latest version may fix this issue.
+          """
+        else if atomCheck? and not atomCheck.upToDate
+          issueButton.remove()
+
+          fatalNotification.innerHTML += """
+            Atom is out of date: #{atomCheck.installedVersion} installed;
+            #{atomCheck.latestVersion} latest.
+            Upgrading to the <a href='https://github.com/atom/atom/releases/tag/v#{atomCheck.latestVersion}'>latest version</a> may fix this issue.
           """
         else
           issueButton.setAttribute('href', newIssueUrl) if newIssueUrl?

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -89,6 +89,22 @@ module.exports =
   filterActivePackages: (packages) ->
     "#{pack.name}, v#{pack.version}" for pack in (packages ? []) when atom.packages.getActivePackage(pack.name)?
 
+  getLatestAtomData: ->
+    atomUrl = 'https://atom.io/api/updates'
+    new Promise (resolve, reject) ->
+      $.ajax atomUrl,
+        accept: 'application/vnd.github.v3+json'
+        contentType: "application/json"
+        success: (data) -> resolve(data)
+        error: (error) -> reject(error)
+
+  checkAtomUpToDate: ->
+    @getLatestAtomData().then (latestAtomData) =>
+      installedVersion = atom.getVersion()
+      latestVersion = latestAtomData.name
+      upToDate = installedVersion? and semver.gte(installedVersion, latestVersion)
+      { upToDate, latestVersion, installedVersion }
+
   getPackageVersion: (packageName) ->
     pack = atom.packages.getLoadedPackage(packageName)
     pack?.metadata.version


### PR DESCRIPTION
This is related to the following idea from https://github.com/atom/notifications/issues/37:

> we could prevent issues being created if the user is using an older version of Atom

In https://github.com/atom/notifications/issues/37#issuecomment-73769920 @benogle said:

> I'd love to do this. I wanted to prompt to upgrade atom if it was out of date just like the package update.

So, here's an attempt at this. It uses the same approach as the existing check for packages:

1. get the latest version of Atom from `atom.io/api` and the version which is currently running
2. if the latest version is greater than the current version, it adds a message to the notification and tells the user that Atom is out of date and that they should update to the latest version:

  > Atom is out of date: 0.188.0 installed; 0.189.0 latest. Upgrading to the <a href='https://github.com/atom/atom/releases/tag/v0.189.0'>latest version</a> may fix this issue.

3. in addition to 2), the button for creating an issue is removed.

Here's how that looks for an exception thrown from a package:

![error](https://cloud.githubusercontent.com/assets/38924/6998226/9c9b1d1e-dbd9-11e4-82e7-c45e270bca2d.gif)

A few notes:
* Notice that there's no "Update to the latest version" or "Check for updates" button in case we detect that Atom is out of date. Instead there is a link to the latest release on GitHub, where the user can download that version. It was easier to just do a link here instead of thinking of all types of situations/problems with upgrading (e.g. OSes on which we don't have an auto-updater, and folks building Atom from source). If the clipboard button looks strange all on its own, we could turn that link into a "View latest release" button?
* In the example above, the full text shown to the user is: "The error was thrown from the the-closer package. Atom is out of date: 0.188.0-d462895 installed; 0.189.0 latest. Upgrading to the latest version may fix this issue". That transition form the first sentence to the second sentence isn't as smooth as I'd like it to be -- any suggestions on improving that so that it reads better?
* Notice that the button for creating an issue is shown as first when the notification is created and then hidden quickly after that when it's detected that Atom is out of date. I don't think this is a blocker, but I did notice it. Also, that behavior is already present in the package [here](https://github.com/atom/notifications/blob/7b90779e4c1fa7cbaa58581875d69720b32f67e9/lib/notification-element.coffee#L114).

cc @benogle @kevinsawicki for :eyes: and :thought_balloon: 