### PR TITLE
Detect locally installed out-of-date core packages

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -146,7 +146,7 @@ class NotificationElement extends HTMLElement
             atom.commands.dispatch(atom.views.getView(atom.workspace), command)
 
           fatalNotification.innerHTML += """
-            #{packageName} is out of date: #{packageCheck.installedVersion} installed;
+            <code>#{packageName}</code> is out of date: #{packageCheck.installedVersion} installed;
             #{packageCheck.latestVersion} latest.
             Upgrading to the latest version may fix this issue.
           """
@@ -155,7 +155,7 @@ class NotificationElement extends HTMLElement
 
           fatalNotification.innerHTML += """
             <br><br>
-            Locally installed core Atom package #{packageName} is out of date: #{packageCheck.installedVersion} installed locally;
+            Locally installed core Atom package <code>#{packageName}</code> is out of date: #{packageCheck.installedVersion} installed locally;
             #{packageCheck.versionShippedWithAtom} included with the version of Atom you're running.
             Removing the locally installed version may fix this issue.
           """

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -150,6 +150,15 @@ class NotificationElement extends HTMLElement
             #{packageCheck.latestVersion} latest.
             Upgrading to the latest version may fix this issue.
           """
+        else if packageCheck? and not packageCheck.upToDate and packageCheck.isCore
+          issueButton.remove()
+
+          fatalNotification.innerHTML += """
+            <br><br>
+            Locally installed core Atom package #{packageName} is out of date: #{packageCheck.installedVersion} installed locally;
+            #{packageCheck.versionShippedWithAtom} included with the version of Atom you're running.
+            Removing the locally installed version with <code>apm unlink</code> may fix this issue.
+          """
         else if atomCheck? and not atomCheck.upToDate
           issueButton.remove()
 

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -1,4 +1,4 @@
-fs = require 'fs'
+fs = require 'fs-plus'
 path = require 'path'
 marked = require 'marked'
 
@@ -157,7 +157,14 @@ class NotificationElement extends HTMLElement
             <br><br>
             Locally installed core Atom package #{packageName} is out of date: #{packageCheck.installedVersion} installed locally;
             #{packageCheck.versionShippedWithAtom} included with the version of Atom you're running.
-            Removing the locally installed version with <code>apm unlink</code> may fix this issue.
+            Removing the locally installed version may fix this issue.
+          """
+
+          packagePath = atom.packages.getLoadedPackage(packageName).path
+          if fs.isSymbolicLinkSync(packagePath)
+            fatalNotification.innerHTML += """
+            <br><br>
+            Use: <code>apm unlink #{packagePath}</code>
           """
         else if atomCheck? and not atomCheck.upToDate
           issueButton.remove()

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -160,7 +160,7 @@ class NotificationElement extends HTMLElement
             Removing the locally installed version may fix this issue.
           """
 
-          packagePath = atom.packages.getLoadedPackage(packageName).path
+          packagePath = atom.packages.getLoadedPackage(packageName)?.path
           if fs.isSymbolicLinkSync(packagePath)
             fatalNotification.innerHTML += """
             <br><br>

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -110,7 +110,7 @@ module.exports =
     pack?.metadata.version
 
   getPackageVersionShippedWithAtom: (packageName) ->
-    require(path.join(atom.packages.resourcePath, 'package.json')).packageDependencies[packageName]
+    require(path.join(atom.getLoadSettings().resourcePath, 'package.json')).packageDependencies[packageName]
 
   getLatestPackageData: (packageName) ->
     packagesUrl = 'https://atom.io/api/packages'

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -109,6 +109,9 @@ module.exports =
     pack = atom.packages.getLoadedPackage(packageName)
     pack?.metadata.version
 
+  getPackageVersionShippedWithAtom: (packageName) ->
+    require(path.join(atom.packages.resourcePath, 'package.json')).packageDependencies[packageName]
+
   getLatestPackageData: (packageName) ->
     packagesUrl = 'https://atom.io/api/packages'
     new Promise (resolve, reject) ->
@@ -124,4 +127,13 @@ module.exports =
       upToDate = installedVersion? and semver.gte(installedVersion, latestPackageData.releases.latest)
       latestVersion = latestPackageData.releases.latest
       isCore = latestPackageData.repository.url.startsWith('https://github.com/atom/')
-      { isCore, upToDate, latestVersion, installedVersion }
+
+      if isCore
+        # A core package is out of date if the version which is being used
+        # is lower than the version which normally ships with the version
+        # of Atom which is running. This will happen when there's a locally
+        # installed version of the package with a lower version than Atom's.
+        versionShippedWithAtom = @getPackageVersionShippedWithAtom(packageName)
+        upToDate = installedVersion? and semver.gte(installedVersion, versionShippedWithAtom)
+
+      { isCore, upToDate, latestVersion, installedVersion, versionShippedWithAtom }


### PR DESCRIPTION
This is another possible improvement taken out from https://github.com/atom/notifications/issues/37. In https://github.com/atom/notifications/issues/37#issuecomment-73769920, @benogle said:

> It might be interesting to check to see if atom packages are installed locally, then display a nice message about it.

I agree. This doesn't happen often, but it's super-:confused: for users when it does. This PR is an attempt to detect those situations and display a more helpful error message.

Here's how that will look:

![screen shot 2015-04-14 at 12 53 33](https://cloud.githubusercontent.com/assets/38924/7135324/d6632474-e2a5-11e4-8e5b-3046b7006e98.png)

The error message shown to users is:

> The error was thrown from the settings-view package. 

> Locally installed core Atom package settings-view is out of date: 0.180.0 installed locally; 0.191.0 included with the version of Atom you're running. Removing the locally installed version with apm unlink may fix this issue.

Note: this PR changes what "up to date" means for a package (from the perspective of the Notifications package which is making the call on this). **If the package is not a core package**, it's considered up to date if the locally installed version matches the version published on apm. (This has been the behavior so far for all packages). However, **core packages** are considered up to date if the locally installed version is greater or equal to the version which ships with the version of Atom they are running. So, what's published on apm doesn't really matter for core packages -- we just check what's installed locally and what shipped with Atom.

This check comes _before_ checking if Atom itself is out of date because if a core package is out of date, then it would be out of date even after updating Atom (because the locally installed version would still be there). If the core package is up to date with regard to the Atom version they're running, but Atom itself isn't up to date -- then we tell the user to upgrade Atom.

cc @benogle @kevinsawicki for :eyes:. And cc @atom/issue-triage :pager: 