### PR TITLE
Shrink package size

### DIFF
--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -162,8 +162,11 @@ class CommandLogger
   #
   # Returns the {String} format of the command time.
   formatTime: (time) ->
-    moment ?= require 'moment'
-    moment(time).format(@dateFmt)
+    minutes = Math.floor(time / 60000)
+    seconds = Math.floor(((time % 60000) / 1000) * 10) / 10
+    seconds = "0#{seconds}" if seconds < 10
+    seconds = "#{seconds}.0" if Math.floor(seconds) isnt seconds
+    "-#{minutes}:#{seconds}"
 
   # Private: Initializes the log structure for speed.
   initLog: ->

--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -1,8 +1,6 @@
 # Originally from lee-dohm/bug-report
 # https://github.com/lee-dohm/bug-report/blob/master/lib/command-logger.coffee
 
-moment = null
-
 # Command names that are ignored and not included in the log. This uses an Object to provide fast
 # string matching.
 ignoredCommands =
@@ -26,9 +24,6 @@ class CommandLogger
 
   @start: ->
     @instance().start()
-
-  # Public: Format of time information.
-  dateFmt: '-m:ss.S'
 
   # Public: Maximum size of the log.
   logSize: 16

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -50,7 +50,7 @@ module.exports =
 
       plistBuddy.onWillThrowError ({handle}) ->
         handle()
-        resolve('Unknown OSX version')
+        resolve({})
 
   winVersionText: ->
     new Promise (resolve, reject) ->

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "fs-plus": "^2.6.0",
     "jquery": "^2",
     "marked": "^0.3",
-    "moment": "^2.8.4",
     "semver": "^4.2.0",
     "stacktrace-parser": "0.1.1",
     "temp": "^0.8.1"

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
     "jquery": "^2",
     "marked": "^0.3",
     "moment": "^2.8.4",
-    "plist": "^1.1.0",
     "semver": "^4.2.0",
     "stacktrace-parser": "0.1.1",
     "temp": "^0.8.1"


### PR DESCRIPTION
While auditing the bundle size over in https://github.com/atom/atom/pull/6447 I noticed that this package was one of the largest bundled with Atom.

This was due to the `moment` and `plist` libraries both being over 3MB:

```sh
> du -sh node_modules/notifications/node_modules/*
3.5M	node_modules/notifications/node_modules/moment
3.3M	node_modules/notifications/node_modules/plist
```

This pull request does the following to reduce the package size:
  * Spawn [PlistBuddy](https://developer.apple.com/library/mac/documentation/Darwin/Reference/ManPages/man8/PlistBuddy.8.html) instead of using the plist library
  * Manually format dates instead of using the moment library

/cc @benogle 