### PR TITLE
Focus active pane on notification removal only if the notification was focused

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -184,7 +184,6 @@ class NotificationElement extends HTMLElement
   removeNotification: ->
     @classList.add('remove')
     @removeNotificationAfterTimeout()
-    atom.workspace.getActivePane().activate() if this is document.activeElement
 
   handleRemoveNotificationClick: ->
     @model.dismiss()
@@ -212,6 +211,8 @@ class NotificationElement extends HTMLElement
     , @visibilityDuration
 
   removeNotificationAfterTimeout: ->
+    atom.workspace.getActivePane().activate() if this is document.activeElement
+    
     setTimeout =>
       @remove()
     , @animationDuration # keep in sync with CSS animation

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -184,7 +184,7 @@ class NotificationElement extends HTMLElement
   removeNotification: ->
     @classList.add('remove')
     @removeNotificationAfterTimeout()
-    atom.workspace.getActivePane().activate()
+    atom.workspace.getActivePane().activate() if this is document.activeElement
 
   handleRemoveNotificationClick: ->
     @model.dismiss()

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -108,8 +108,6 @@ describe "Notifications", ->
           notificationElement.focus()
           notificationElement.querySelector('.close.icon').click()
 
-          expect(atom.views.getView(atom.workspace.getActiveTextEditor())).toHaveFocus()
-
           advanceClock(NotificationElement::visibilityDuration)
           expect(notificationElement).toHaveClass 'remove'
 
@@ -129,6 +127,36 @@ describe "Notifications", ->
 
         advanceClock(NotificationElement::animationDuration * 3)
         expect(notificationContainer.childNodes.length).toBe 0
+
+      it "focuses the active pane only if the dismissed notification has focus", ->
+        jasmine.attachToDOM(workspaceElement)
+
+        waitsForPromise ->
+          atom.workspace.open()
+
+        runs ->
+          notification1 = atom.notifications.addSuccess('First message', dismissable: true)
+          notification2 = atom.notifications.addError('Second message', dismissable: true)
+          notificationElement1 = notificationContainer.querySelector('atom-notification.success')
+          notificationElement2 = notificationContainer.querySelector('atom-notification.error')
+
+          expect(notificationContainer.childNodes.length).toBe 2
+
+          notificationElement2.focus()
+
+          notification1.dismiss()
+
+          advanceClock(NotificationElement::visibilityDuration)
+          advanceClock(NotificationElement::animationDuration)
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notificationElement2).toHaveFocus()
+
+          notificationElement2.querySelector('.close.icon').click()
+
+          advanceClock(NotificationElement::visibilityDuration)
+          advanceClock(NotificationElement::animationDuration)
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(atom.views.getView(atom.workspace.getActiveTextEditor())).toHaveFocus()
 
     describe "when an autoclose notification is added", ->
       it "closes and removes the message after a given amount of time", ->


### PR DESCRIPTION
In https://github.com/atom/atom/issues/6439 a use-case was mentioned where dismissing a notification shouldn't focus the active pane -- programmatically dismissing a notification while some other panels are focused (e.g. the command palette). I think that makes sense and I think this change closes https://github.com/atom/atom/issues/6439.

Here's a rundown of the commits:

* 6a8617e adds a failing spec to demonstrate the problem pointed out in https://github.com/atom/atom/issues/6439. Running `apm test` at that commit produces this failure:

  ```
Notifications
  when notifications are added to atom.notifications
    when a dismissable notification is added
      it focuses the active pane only if the dismissed notification has focus
        Expected element '[object HTMLElement]' or its descendants to have focus.
          at [object Object].<anonymous> (/Users/izuzak/github/notifications/spec/notifications-spec.coffee:152:40)
          at _fulfilled (/Users/izuzak/github/atom/node_modules/q/q.js:794:54)
          at self.promiseDispatch.done (/Users/izuzak/github/atom/node_modules/q/q.js:823:30)
          at Promise.promise.promiseDispatch (/Users/izuzak/github/atom/node_modules/q/q.js:756:13)
          at /Users/izuzak/github/atom/node_modules/q/q.js:564:44
          at flush (/Users/izuzak/github/atom/node_modules/q/q.js:110:17)
          at process._tickCallback (node.js:357:13)


Finished in 14.885 seconds
48 tests, 125 assertions, 1 failure, 0 skipped
```

* 2b5f9f7 fixes the failing spec by checking if the notification had focus when it's dismissed. If it does have focus -- then the active pane is focused. If it doesn't have focus -- then focus isn't touched (assuming that whatever has focus is what should have focus).

* ff8eeaa moves the check + focus statement so that it's performed in every removal scenario, including notifications which were removed automatically after a timeout (non-dismissible notifications). This covers the case where a notification which is not dismissible is shown and the user clicks the notification, and after the timeout the notification is removed (and focus is now put to the active pane).

cc @benogle @kevinsawicki for :eyes: 