### PR TITLE
Don't show notifications for stacks without absolute file paths

### DIFF
--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -157,6 +157,20 @@ describe "Notifications", ->
           expect(notificationContainer.childNodes.length).toBe 0
           expect(fatalError).toBe null
 
+      describe "when the exception has no core or package paths in the stack trace", ->
+        it "does not display a notification", ->
+          atom.notifications.clear()
+          spyOn(atom, 'inDevMode').andReturn false
+          handler = jasmine.createSpy('onWillThrowErrorHandler')
+          atom.onWillThrowError(handler)
+          fs.readFile(__dirname)
+
+          waitsFor ->
+            handler.callCount is 1
+
+          runs ->
+            expect(atom.notifications.getNotifications().length).toBe 0
+
       describe "when there are multiple packages in the stack trace", ->
         beforeEach ->
           stack = """


### PR DESCRIPTION
There are cases where a stack traces only contains file paths for node built-ins such as process and fs and are impossible to trace to a specific package or core file, so don't show notifications for them.

This can be as simple as calling `fs.readFile('/')` without a callback which currently causes a notification with a stack trace of:

```
Error: EISDIR: illegal operation on a directory, read
  at Error (native)
```

This pull request scans each stack and only shows notifications for ones that contain at least one absolute path meaning it comes from a **known** package or core source file.

The errors still go to Console tab in  the dev tools.

Closes https://github.com/atom/atom/issues/4708
Closes https://github.com/atom/atom/issues/4710
Closes https://github.com/atom/atom/issues/4735
Closes https://github.com/atom/atom/issues/4805
Closes https://github.com/atom/atom/issues/5315
Closes https://github.com/atom/atom/issues/5634
Closes https://github.com/atom/atom/issues/5956
Closes https://github.com/atom/atom/issues/6095
Closes https://github.com/atom/atom/issues/6184
Closes https://github.com/atom/atom/issues/6191
Closes https://github.com/atom/atom/issues/6213
Closes https://github.com/atom/atom/issues/6256
Closes https://github.com/atom/atom/issues/6326
Closes https://github.com/atom/atom/issues/6339
Closes https://github.com/atom/atom/issues/6468
Closes https://github.com/atom/atom/issues/6804

/cc @izuzak I tried to link all the relevant uncaught issues I could find
/cc @benogle 