### PR TITLE
Add support for buttons and description

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -21,17 +21,27 @@ NotificationTemplate = """
 """
 
 FatalMetaNotificationTemplate = """
-  <div class="fatal-notification"></div>
+  <div class="meta-notification fatal-notification"></div>
   <div class="btn-toolbar">
     <a href="#" class="btn-issue btn btn-error"></a>
     <a href="#" class="btn-copy-report icon icon-clippy" title="Copy error report to clipboard"></a>
   </div>
 """
 
+MetaNotificationTemplate = """
+  <div class="meta-notification"></div>
+"""
+
+ButtonListTemplate = """
+  <div class="btn-toolbar"></div>
+"""
+
 class NotificationElement extends HTMLElement
   animationDuration: 700
   visibilityDuration: 5000
   fatalTemplate: TemplateHelper.create(FatalMetaNotificationTemplate)
+  metaTemplate: TemplateHelper.create(MetaNotificationTemplate)
+  buttonListTemplate: TemplateHelper.create(ButtonListTemplate)
 
   constructor: ->
 
@@ -63,13 +73,15 @@ class NotificationElement extends HTMLElement
 
     @innerHTML = NotificationTemplate
 
+    options = @model.getOptions()
+
     notificationContainer = @querySelector('.message')
     notificationContainer.innerHTML = marked(@model.getMessage())
 
     if detail = @model.getDetail()
       addSplitLinesToContainer(@querySelector('.detail-content'), detail)
 
-      if stack = @model.getOptions().stack
+      if stack = options.stack
         stackToggle = @querySelector('.stack-toggle')
         stackContainer = @querySelector('.stack-container')
 
@@ -77,6 +89,13 @@ class NotificationElement extends HTMLElement
 
         stackToggle.addEventListener 'click', (e) => @handleStackTraceToggleClick(e, stackContainer)
         @handleStackTraceToggleClick({currentTarget: stackToggle}, stackContainer)
+
+    if metaContent = options.meta
+      metaContainer = @querySelector('.meta')
+      metaContainer.appendChild(TemplateHelper.render(@metaTemplate))
+      metaNotification = @querySelector('.meta-notification')
+      metaNotification.innerHTML = marked(metaContent)
+      @classList.add('has-meta')
 
     if @model.isDismissable()
       closeButton = @querySelector('.close')

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -21,7 +21,7 @@ NotificationTemplate = """
 """
 
 FatalMetaNotificationTemplate = """
-  <div class="meta-notification fatal-notification"></div>
+  <div class="description fatal-notification"></div>
   <div class="btn-toolbar">
     <a href="#" class="btn-issue btn btn-error"></a>
     <a href="#" class="btn-copy-report icon icon-clippy" title="Copy error report to clipboard"></a>
@@ -29,7 +29,7 @@ FatalMetaNotificationTemplate = """
 """
 
 MetaNotificationTemplate = """
-  <div class="meta-notification"></div>
+  <div class="description"></div>
 """
 
 ButtonListTemplate = """
@@ -95,12 +95,12 @@ class NotificationElement extends HTMLElement
         stackToggle.addEventListener 'click', (e) => @handleStackTraceToggleClick(e, stackContainer)
         @handleStackTraceToggleClick({currentTarget: stackToggle}, stackContainer)
 
-    if metaContent = options.meta
-      @classList.add('has-meta')
+    if metaContent = options.description
+      @classList.add('has-description')
       metaContainer = @querySelector('.meta')
       metaContainer.appendChild(TemplateHelper.render(@metaTemplate))
-      metaNotification = @querySelector('.meta-notification')
-      metaNotification.innerHTML = marked(metaContent)
+      description = @querySelector('.description')
+      description.innerHTML = marked(metaContent)
 
     if options.buttons and options.buttons.length > 0
       @classList.add('has-buttons')

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -36,12 +36,17 @@ ButtonListTemplate = """
   <div class="btn-toolbar"></div>
 """
 
+ButtonTemplate = """
+  <a href="#" class="btn"></a>
+"""
+
 class NotificationElement extends HTMLElement
   animationDuration: 700
   visibilityDuration: 5000
   fatalTemplate: TemplateHelper.create(FatalMetaNotificationTemplate)
   metaTemplate: TemplateHelper.create(MetaNotificationTemplate)
   buttonListTemplate: TemplateHelper.create(ButtonListTemplate)
+  buttonTemplate: TemplateHelper.create(ButtonTemplate)
 
   constructor: ->
 
@@ -91,11 +96,30 @@ class NotificationElement extends HTMLElement
         @handleStackTraceToggleClick({currentTarget: stackToggle}, stackContainer)
 
     if metaContent = options.meta
+      @classList.add('has-meta')
       metaContainer = @querySelector('.meta')
       metaContainer.appendChild(TemplateHelper.render(@metaTemplate))
       metaNotification = @querySelector('.meta-notification')
       metaNotification.innerHTML = marked(metaContent)
-      @classList.add('has-meta')
+
+    if options.buttons and options.buttons.length > 0
+      @classList.add('has-buttons')
+      metaContainer = @querySelector('.meta')
+      metaContainer.appendChild(TemplateHelper.render(@buttonListTemplate))
+      toolbar = @querySelector('.btn-toolbar')
+      buttonClass = @model.getType()
+      buttonClass = 'error' if buttonClass is 'fatal'
+      buttonClass = "btn-#{buttonClass}"
+      options.buttons.forEach (button) =>
+        toolbar.appendChild(TemplateHelper.render(@buttonTemplate))
+        buttonEl = toolbar.childNodes[toolbar.childNodes.length - 1]
+        buttonEl.textContent = button.text
+        buttonEl.classList.add(buttonClass)
+        if button.className?
+          buttonEl.classList.add.apply(buttonEl.classList, button.className.split(' '))
+        if button.onDidClick?
+          buttonEl.addEventListener 'click', (e) ->
+            button.onDidClick.call(this, e)
 
     if @model.isDismissable()
       closeButton = @querySelector('.close')

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -147,17 +147,17 @@ describe "Notifications", ->
         advanceClock(NotificationElement::animationDuration)
         expect(notificationContainer.childNodes.length).toBe 0
 
-    describe "when the `meta` option is used", ->
-      it "displays the meta text in the .meta-notification element", ->
-        atom.notifications.addSuccess('A message', meta: 'This is [a link](http://atom.io)')
+    describe "when the `description` option is used", ->
+      it "displays the description text in the .description element", ->
+        atom.notifications.addSuccess('A message', description: 'This is [a link](http://atom.io)')
         notification = notificationContainer.querySelector('atom-notification.success')
-        expect(notification).toHaveClass('has-meta')
+        expect(notification).toHaveClass('has-description')
         expect(notification.querySelector('.meta')).toBeVisible()
-        expect(notification.querySelector('.meta-notification').textContent.trim()).toBe 'This is a link'
-        expect(notification.querySelector('.meta-notification a').href).toBe 'http://atom.io/'
+        expect(notification.querySelector('.description').textContent.trim()).toBe 'This is a link'
+        expect(notification.querySelector('.description a').href).toBe 'http://atom.io/'
 
     describe "when the `buttons` options is used", ->
-      it "displays the buttons in the .meta-notification element", ->
+      it "displays the buttons in the .description element", ->
         clicked = []
         atom.notifications.addSuccess 'A message',
           buttons: [{

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -52,6 +52,8 @@ describe "Notifications", ->
       advanceClock(NotificationElement::animationDuration)
 
       notificationContainer = workspaceElement.querySelector('atom-notifications')
+      jasmine.attachToDOM(workspaceElement)
+
       spyOn($, 'ajax')
 
     it "adds an atom-notification element to the container with a class corresponding to the type", ->
@@ -62,6 +64,7 @@ describe "Notifications", ->
       expect(notificationContainer.childNodes.length).toBe 1
       expect(notification).toHaveClass 'success'
       expect(notification.querySelector('.message').textContent.trim()).toBe 'A message'
+      expect(notification.querySelector('.meta')).not.toBeVisible()
 
       atom.notifications.addInfo('A message')
       expect(notificationContainer.childNodes.length).toBe 2
@@ -143,6 +146,15 @@ describe "Notifications", ->
 
         advanceClock(NotificationElement::animationDuration)
         expect(notificationContainer.childNodes.length).toBe 0
+
+    describe "when the `meta` option is used", ->
+      it "displays the meta text in the .meta-notification element", ->
+        atom.notifications.addSuccess('A message', meta: 'This is [a link](http://atom.io)')
+        notification = notificationContainer.querySelector('atom-notification.success')
+        expect(notification).toHaveClass('has-meta')
+        expect(notification.querySelector('.meta')).toBeVisible()
+        expect(notification.querySelector('.meta-notification').textContent.trim()).toBe 'This is a link'
+        expect(notification.querySelector('.meta-notification a').href).toBe 'http://atom.io/'
 
     describe "when an exception is thrown", ->
       [notificationContainer, fatalError, issueBody] = []

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -156,6 +156,37 @@ describe "Notifications", ->
         expect(notification.querySelector('.meta-notification').textContent.trim()).toBe 'This is a link'
         expect(notification.querySelector('.meta-notification a').href).toBe 'http://atom.io/'
 
+    describe "when the `buttons` options is used", ->
+      it "displays the buttons in the .meta-notification element", ->
+        clicked = []
+        atom.notifications.addSuccess 'A message',
+          buttons: [{
+            text: 'Button One'
+            className: 'btn-one'
+            onDidClick: -> clicked.push 'one'
+          },{
+            text: 'Button Two'
+            className: 'btn-two'
+            onDidClick: -> clicked.push 'two'
+          }]
+
+        notification = notificationContainer.querySelector('atom-notification.success')
+        expect(notification).toHaveClass('has-buttons')
+        expect(notification.querySelector('.meta')).toBeVisible()
+
+        btnOne = notification.querySelector('.btn-one')
+        btnTwo = notification.querySelector('.btn-two')
+
+        expect(btnOne).toHaveClass 'btn-success'
+        expect(btnOne.textContent).toBe 'Button One'
+        expect(btnTwo).toHaveClass 'btn-success'
+        expect(btnTwo.textContent).toBe 'Button Two'
+
+        btnTwo.click()
+        btnOne.click()
+
+        expect(clicked).toEqual ['two', 'one']
+
     describe "when an exception is thrown", ->
       [notificationContainer, fatalError, issueBody] = []
       describe "when the editor is in dev mode", ->

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -177,7 +177,6 @@ atom-notification {
     }
 
     .stack-toggle {
-      display: block;
       margin-top: @component-padding;
 
       .icon:before {
@@ -190,8 +189,12 @@ atom-notification {
     }
   }
 
-  .fatal-notification {
+  .meta-notification {
     font-size: .8em;
+
+    p:last-child {
+      margin-bottom: 0;
+    }
   }
 
   .btn-toolbar {

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -94,6 +94,8 @@ atom-notification {
   }
 
   &.fatal .meta,
+  &.has-meta .meta,
+  &.has-buttons .meta,
   &.has-close .close,
   &.has-detail .detail,
   &.has-stack .stack-toggle,

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -94,7 +94,7 @@ atom-notification {
   }
 
   &.fatal .meta,
-  &.has-meta .meta,
+  &.has-description .meta,
   &.has-buttons .meta,
   &.has-close .close,
   &.has-detail .detail,
@@ -189,7 +189,7 @@ atom-notification {
     }
   }
 
-  .meta-notification {
+  .description {
     font-size: .8em;
 
     p:last-child {


### PR DESCRIPTION
I'd like to leave support for these private for now. Naming could change.

All the permutations:

![screen shot 2015-05-19 at 2 45 17 pm](https://cloud.githubusercontent.com/assets/69169/7714765/6602cac0-fe36-11e4-827b-3bc15de71b92.png)
