### PR TITLE
Log Linux distro name in issue body

### DIFF
--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -56,7 +56,7 @@ module.exports =
 
   linuxVersionText: ->
     new Promise (resolve, reject) ->
-      @linuxVersionInfo.then (info) ->
+      @linuxVersionInfo().then (info) ->
         return "#{os.platform()} #{os.release()}" unless info.DistroName and info.DistroVersion
         "#{info.DistroName} #{info.DistroVersion}"
 

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -57,8 +57,10 @@ module.exports =
   linuxVersionText: ->
     new Promise (resolve, reject) ->
       @linuxVersionInfo().then (info) ->
-        return "#{os.platform()} #{os.release()}" unless info.DistroName and info.DistroVersion
-        "#{info.DistroName} #{info.DistroVersion}"
+        if info.DistroName and info.DistroVersion
+          "#{info.DistroName} #{info.DistroVersion}"
+        else
+          "#{os.platform()} #{os.release()}"
 
   linuxVersionInfo: ->
     new Promise (resolve, reject) ->


### PR DESCRIPTION
This logs the Linux distro name in the issue body if an error is thrown instead of the more generic `linux <kernel version>` we get now – this should help quite a bit for troubleshooting distro-specific issues.

/cc @atom/feedback 