### PR TITLE
Remove extra promise when computing linux OS details

### DIFF
--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -55,12 +55,11 @@ module.exports =
         resolve({})
 
   linuxVersionText: ->
-    new Promise (resolve, reject) ->
-      @linuxVersionInfo().then (info) ->
-        if info.DistroName and info.DistroVersion
-          "#{info.DistroName} #{info.DistroVersion}"
-        else
-          "#{os.platform()} #{os.release()}"
+    @linuxVersionInfo().then (info) ->
+      if info.DistroName and info.DistroVersion
+        "#{info.DistroName} #{info.DistroVersion}"
+      else
+        "#{os.platform()} #{os.release()}"
 
   linuxVersionInfo: ->
     new Promise (resolve, reject) ->


### PR DESCRIPTION
This should fix https://github.com/atom/notifications/issues/70 -- as far as I can tell, there's an extra Promise in there (e.g. compare the `linuxVersionText` flow with the `macVersionText` flow).

/cc @mnquintana @kevinsawicki 