### PR TITLE
Use a more correct way to check if package is core

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -255,7 +255,7 @@ class NotificationElement extends HTMLElement
 
   removeNotificationAfterTimeout: ->
     atom.workspace.getActivePane().activate() if this is document.activeElement
-    
+
     setTimeout =>
       @remove()
     , @animationDuration # keep in sync with CSS animation

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -172,14 +172,13 @@ module.exports =
       installedVersion = @getPackageVersion(packageName)
       upToDate = installedVersion? and semver.gte(installedVersion, latestPackageData.releases.latest)
       latestVersion = latestPackageData.releases.latest
-      isCore = latestPackageData.repository.url.startsWith('https://github.com/atom/')
+      versionShippedWithAtom = @getPackageVersionShippedWithAtom(packageName)
 
-      if isCore
+      if isCore = versionShippedWithAtom?
         # A core package is out of date if the version which is being used
         # is lower than the version which normally ships with the version
         # of Atom which is running. This will happen when there's a locally
         # installed version of the package with a lower version than Atom's.
-        versionShippedWithAtom = @getPackageVersionShippedWithAtom(packageName)
         upToDate = installedVersion? and semver.gte(installedVersion, versionShippedWithAtom)
 
       {isCore, upToDate, latestVersion, installedVersion, versionShippedWithAtom}

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -499,6 +499,25 @@ describe "Notifications", ->
             expect(fatalNotification.textContent).toContain 'Upgrading to the latest'
             expect(button.getAttribute('href')).toBe '#'
 
+        describe "when the package is an atom-owned non-core package", ->
+          beforeEach ->
+            generateFakeAjaxResponses
+              packageResponse:
+                repository: url: 'https://github.com/atom/sort-lines'
+                releases: latest: '0.10.0'
+            generateException()
+            fatalError = notificationContainer.querySelector('atom-notification.fatal')
+            waitsForPromise ->
+              fatalError.getRenderPromise().then -> issueBody = fatalError.issue.issueBody
+
+          it "asks the user to update their packages", ->
+            fatalNotification = fatalError.querySelector('.fatal-notification')
+            button = fatalError.querySelector('.btn')
+
+            expect(button.textContent).toContain 'Check for package updates'
+            expect(fatalNotification.textContent).toContain 'Upgrading to the latest'
+            expect(button.getAttribute('href')).toBe '#'
+
         describe "when the package is a core package", ->
           beforeEach ->
             generateFakeAjaxResponses

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -4,6 +4,7 @@ path = require 'path'
 temp = require('temp').track()
 {Notification} = require 'atom'
 NotificationElement = require '../lib/notification-element'
+NotificationIssue = require '../lib/notification-issue'
 
 describe "Notifications", ->
   [workspaceElement, activationPromise] = []
@@ -484,8 +485,10 @@ describe "Notifications", ->
           beforeEach ->
             generateFakeAjaxResponses
               packageResponse:
-                repository: url: 'https://github.com/someguy/notifications'
+                repository: url: 'https://github.com/someguy/somepackage'
                 releases: latest: '0.10.0'
+            spyOn(NotificationIssue.prototype, 'getPackageName').andCallFake -> "somepackage"
+            spyOn(NotificationIssue.prototype, 'getRepoUrl').andCallFake -> "https://github.com/someguy/somepackage"
             generateException()
             fatalError = notificationContainer.querySelector('atom-notification.fatal')
             waitsForPromise ->
@@ -505,8 +508,11 @@ describe "Notifications", ->
               packageResponse:
                 repository: url: 'https://github.com/atom/sort-lines'
                 releases: latest: '0.10.0'
+            spyOn(NotificationIssue.prototype, 'getPackageName').andCallFake -> "sort-lines"
+            spyOn(NotificationIssue.prototype, 'getRepoUrl').andCallFake -> "https://github.com/atom/sort-lines"
             generateException()
             fatalError = notificationContainer.querySelector('atom-notification.fatal')
+
             waitsForPromise ->
               fatalError.getRenderPromise().then -> issueBody = fatalError.issue.issueBody
 


### PR DESCRIPTION
This should fix https://github.com/atom/notifications/issues/74:

* d83863a adds a failing spec to demonstrate the problem with the current way of checking if a package is core
* 322943f fixes the problem by switching the check to use Atom's package.json
* a49e705 tweaks some tests which started to fail because of how the name and repo url of the package which threw the exception were faked and used to determine if the package is core

cc @kevinsawicki for :eyes: 