### PR TITLE
Exit loop in NotificationIssue::findSimilarIssues() when match is found

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -27,7 +27,10 @@ class NotificationIssue
           if data.items?
             issues = {}
             for issue in data.items
-              issues[issue.state] = issue if issue.title.indexOf(@getIssueTitle()) > -1 and not issues[issue.state]?
+              if issue.title.indexOf(@getIssueTitle()) > -1 and not issues[issue.state]?
+                issues[issue.state] = issue
+                break
+
             return resolve(issues) if issues.open? or issues.closed?
           resolve(null)
         error: -> resolve(null)


### PR DESCRIPTION
This is a little change that should speed up issue matching when notification looks for similar issues - it now just breaks out of the loop when it finds a match instead of iterating over every issue.

/cc @atom/feedback 