### PR TITLE
Fix specs on Windows...again

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -8,6 +8,8 @@ UserUtilities = require './user-utilities'
 
 TITLE_CHAR_LIMIT = 100 # Truncate issue title to 100 characters (including ellipsis)
 
+FileURLRegExp = new RegExp('file://\w*/(.*)')
+
 module.exports =
 class NotificationIssue
   constructor: (@notification) ->
@@ -183,11 +185,11 @@ class NotificationIssue
         packagePaths[packageName] = fs.realpathSync(packagePath)
 
     getPackageName = (filePath) =>
-      filePath = /(\((.+?):\d+|\((.+)\)|(.+))/.exec(filePath)[1]
+      filePath = /\((.+?):\d+|\((.+)\)|(.+)/.exec(filePath)[0]
 
       # Stack traces may be a file URI
-      if /file:\/\/(\w*)\/(.*)/.test(filePath)
-        filePath = /file:\/\/(\w*)\/(.*)/.exec(filePath)[2]
+      if match = FileURLRegExp.exec(filePath)
+        filePath = match[1]
 
       if path.isAbsolute(filePath)
         for packName, packagePath of packagePaths

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -183,6 +183,12 @@ class NotificationIssue
         packagePaths[packageName] = fs.realpathSync(packagePath)
 
     getPackageName = (filePath) =>
+      filePath = /(\((.+?):\d+|\((.+)\)|(.+))/.exec(filePath)[1]
+
+      # Stack traces may be a file URI
+      if /file:\/\/(\w*)\/(.*)/.test(filePath)
+        filePath = /file:\/\/(\w*)\/(.*)/.exec(filePath)[2]
+
       if path.isAbsolute(filePath)
         for packName, packagePath of packagePaths
           continue if filePath is 'node.js'
@@ -191,13 +197,7 @@ class NotificationIssue
       @getPackageNameFromFilePath(filePath)
 
     if options.detail?
-      file = /(\((.+?):\d+|\((.+)\)|(.+))/.exec(options.detail)[1]
-
-      # Stack traces may be a file URI
-      if /file:\/\/(\w*)\/(.*)/.test(file)
-        file = /file:\/\/(\w*)\/(.*)/.exec(file)[2]
-
-      packageName = getPackageName(file)
+      packageName = getPackageName(options.detail)
       return packageName if packageName?
 
     if options.stack?
@@ -207,11 +207,6 @@ class NotificationIssue
 
         # Empty when it was run from the dev console
         return unless file
-
-        # Stack traces may be a file URI
-        if /file:\/\/(\w*)\/(.*)/.test(file)
-          file = /file:\/\/(\w*)\/(.*)/.exec(file)[2]
-
         packageName = getPackageName(file)
         return packageName if packageName?
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -190,8 +190,15 @@ class NotificationIssue
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
 
-    if options.detail? and packageName = getPackageName(options.detail)
-      return packageName
+    if options.detail?
+      file = /(.*)(:\d)?/.exec(options.detail)?[1]
+
+      # Stack traces may be a file URI
+      if /file:\/\/(\w*)\/(.*)/.test(file)
+        file = /file:\/\/(\w*)\/(.*)/.exec(file)[2]
+
+      packageName = getPackageName(file)
+      return packageName if packageName?
 
     if options.stack?
       stack = StackTraceParser.parse(options.stack)
@@ -200,6 +207,11 @@ class NotificationIssue
 
         # Empty when it was run from the dev console
         return unless file
+
+        # Stack traces may be a file URI
+        if /file:\/\/(\w*)\/(.*)/.test(file)
+          file = /file:\/\/(\w*)\/(.*)/.exec(file)[2]
+
         packageName = getPackageName(file)
         return packageName if packageName?
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -196,9 +196,8 @@ class NotificationIssue
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
 
-    if options.detail?
-      packageName = getPackageName(options.detail)
-      return packageName if packageName?
+    if options.detail? and packageName = getPackageName(options.detail)
+      return packageName
 
     if options.stack?
       stack = StackTraceParser.parse(options.stack)

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -191,7 +191,7 @@ class NotificationIssue
       @getPackageNameFromFilePath(filePath)
 
     if options.detail?
-      file = /(.*)(:\d)?/.exec(options.detail)?[1]
+      file = /(\((.+?):\d+|\((.+)\)|(.+))/.exec(options.detail)[1]
 
       # Stack traces may be a file URI
       if /file:\/\/(\w*)\/(.*)/.test(file)

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -379,8 +379,7 @@ describe "Notifications", ->
             a + 1
           catch e
             # Pull the file path from the stack
-            # For Windows we have to ignore the starting drive letter (eg C:\)
-            filePath = e.stack.split('\n')[1].match(/\(((\w:\\)[^:]+|([^:]+))/)[1]
+            filePath = e.stack.split('\n')[1].match(/\((.+?):\d+(:\d+)?/)[1]
             window.onerror.call(window, e.toString(), filePath, 2, 3, message: e.toString(), stack: undefined)
 
           notificationContainer = workspaceElement.querySelector('atom-notifications')

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -379,7 +379,7 @@ describe "Notifications", ->
             a + 1
           catch e
             # Pull the file path from the stack
-            filePath = e.stack.split('\n')[1].match(/\((.+?):\d+(:\d+)?/)[1]
+            filePath = e.stack.split('\n')[1].match(/\((.+?):\d+/)[1]
             window.onerror.call(window, e.toString(), filePath, 2, 3, message: e.toString(), stack: undefined)
 
           notificationContainer = workspaceElement.querySelector('atom-notifications')


### PR DESCRIPTION
Specs were passing locally when I created #94...I swear! :P

Anyway, it seems like stack traces are sometimes returning file URIs for me which totally broke package name parsing.  That has been fixed.

/cc @benogle

This also might help with #66.