### PR TITLE
Fix some package detections

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -180,7 +180,7 @@ class NotificationIssue
 
     packagePaths = @getPackagePathsByPackageName()
     for packageName, packagePath of packagePaths
-      if packagePath.indexOf('.atom/dev/packages') > -1 or packagePath.indexOf('.atom/packages') > -1
+      if packagePath.indexOf(path.join('.atom', 'dev', 'packages')) > -1 or packagePath.indexOf(path.join('.atom', 'packages')) > -1
         packagePaths[packageName] = fs.realpathSync(packagePath)
 
     getPackageName = (filePath) =>

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -174,8 +174,9 @@ class NotificationIssue
     return packageName if packageName
 
   getPackageName: ->
+    message = @notification.getMessage()
     options = @notification.getOptions()
-    return unless options.stack? or options.detail?
+    return unless message? or options.stack? or options.detail?
 
     packagePaths = @getPackagePathsByPackageName()
     for packageName, packagePath of packagePaths
@@ -189,6 +190,9 @@ class NotificationIssue
           relativePath = path.relative(packagePath, filePath)
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
+
+    packageName = /Failed to (load|activate) the (.*) package/.exec(message)?[2]
+    return packageName if packageName?
 
     if options.detail? and packageName = getPackageName(options.detail)
       return packageName

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -191,7 +191,7 @@ class NotificationIssue
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
 
-    packageName = /Failed to (load|activate) the (.*) package/.exec(message)?[2]
+    packageName = /Failed to (load|activate) (the|a) (.*) package/.exec(message)?[3]
     return packageName if packageName?
 
     if options.detail? and packageName = getPackageName(options.detail)

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -175,7 +175,9 @@ class NotificationIssue
 
   getPackageName: ->
     options = @notification.getOptions()
-    return unless options.stack? or options.detail? or options.packageName?
+
+    return options.packageName if options.packageName?
+    return unless options.stack? or options.detail?
 
     packagePaths = @getPackagePathsByPackageName()
     for packageName, packagePath of packagePaths
@@ -189,8 +191,6 @@ class NotificationIssue
           relativePath = path.relative(packagePath, filePath)
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
-
-    return options.packageName if options.packageName?
 
     if options.detail? and packageName = getPackageName(options.detail)
       return packageName

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -174,9 +174,8 @@ class NotificationIssue
     return packageName if packageName
 
   getPackageName: ->
-    message = @notification.getMessage()
     options = @notification.getOptions()
-    return unless message? or options.stack? or options.detail?
+    return unless options.stack? or options.detail? or options.packageName?
 
     packagePaths = @getPackagePathsByPackageName()
     for packageName, packagePath of packagePaths
@@ -191,8 +190,7 @@ class NotificationIssue
           return packName unless /^\.\./.test(relativePath)
       @getPackageNameFromFilePath(filePath)
 
-    packageName = /Failed to (load|activate) (the|a) (.*) package/.exec(message)?[3]
-    return packageName if packageName?
+    return options.packageName if options.packageName?
 
     if options.detail? and packageName = getPackageName(options.detail)
       return packageName

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -368,7 +368,7 @@ describe "Notifications", ->
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 
-        fit "displays a fatal error with the package name in the error", ->
+        it "displays a fatal error with the package name in the error", ->
           waitsForPromise ->
             fatalError.getRenderPromise()
 

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -352,7 +352,7 @@ describe "Notifications", ->
               "repository": "https://github.com/atom/notifications"
             }
           """
-          atom.packages.loadPackage('linked-package')
+          atom.packages.enablePackage('linked-package')
 
           stack = """
             ReferenceError: path is not defined

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -356,7 +356,7 @@ describe "Notifications", ->
 
           stack = """
             ReferenceError: path is not defined
-              at Object.module.exports.LinkedPackage.wow (#{path.join(packageDir, 'linked-package.coffee')}:29:15)
+              at Object.module.exports.LinkedPackage.wow (#{path.join(fs.realpathSync(packageDir), 'linked-package.coffee')}:29:15)
               at atom-workspace.subscriptions.add.atom.commands.add.linked-package:wow (#{path.join(packageDir, 'linked-package.coffee')}:18:102)
               at CommandRegistry.module.exports.CommandRegistry.handleCommandEvent (/Applications/Atom.app/Contents/Resources/app/src/command-registry.js:238:29)
               at /Applications/Atom.app/Contents/Resources/app/src/command-registry.js:3:61

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -370,6 +370,74 @@ describe "Notifications", ->
             expect(fatalError.innerHTML).toContain "<a href=\"https://github.com/atom/notifications\">unloaded package</a>"
             expect(fatalError.issue.getPackageName()).toBe 'unloaded'
 
+      describe "when an exception is thrown from a package trying to load", ->
+        beforeEach ->
+          spyOn(atom, 'inDevMode').andReturn false
+          generateFakeAjaxResponses()
+
+          packagesDir = temp.mkdirSync('atom-packages-')
+          atom.packages.packageDirPaths.push(path.join(packagesDir, '.atom', 'packages'))
+          packageDir = path.join(packagesDir, '.atom', 'packages', 'broken-load')
+          fs.writeFileSync path.join(packageDir, 'package.json'), """
+            {
+              "name": "broken-load",
+              "version": "1.0.0",
+              "repository": "https://github.com/atom/notifications"
+            }
+          """
+
+          stack = "TypeError: Cannot read property 'prototype' of undefined\n  at __extends (<anonymous>:1:1)\n  at Object.defineProperty.value [as .coffee] (/Applications/Atom.app/Contents/Resources/app.asar/src/compile-cache.js:169:21)"
+          detail = "TypeError: Cannot read property 'prototype' of undefined"
+          message = "Failed to load the broken-load package"
+          atom.notifications.addFatalError(message, {stack, detail, dismissable: true})
+          notificationContainer = workspaceElement.querySelector('atom-notifications')
+          fatalError = notificationContainer.querySelector('atom-notification.fatal')
+
+        it "displays a fatal error with the package name in the error", ->
+          waitsForPromise ->
+            fatalError.getRenderPromise()
+
+          runs ->
+            expect(notificationContainer.childNodes.length).toBe 1
+            expect(fatalError).toHaveClass 'has-close'
+            expect(fatalError.innerHTML).toContain "TypeError: Cannot read property 'prototype' of undefined"
+            expect(fatalError.innerHTML).toContain "<a href=\"https://github.com/atom/notifications\">broken-load package</a>"
+            expect(fatalError.issue.getPackageName()).toBe 'broken-load'
+
+      describe "when an exception is thrown from a package trying to activate", ->
+        beforeEach ->
+          spyOn(atom, 'inDevMode').andReturn false
+          generateFakeAjaxResponses()
+
+          packagesDir = temp.mkdirSync('atom-packages-')
+          atom.packages.packageDirPaths.push(path.join(packagesDir, '.atom', 'packages'))
+          packageDir = path.join(packagesDir, '.atom', 'packages', 'broken-activation')
+          fs.writeFileSync path.join(packageDir, 'package.json'), """
+            {
+              "name": "broken-activation",
+              "version": "1.0.0",
+              "repository": "https://github.com/atom/notifications"
+            }
+          """
+
+          stack = "TypeError: Cannot read property 'command' of undefined\n  at Object.module.exports.activate (<anonymous>:7:23)\n  at Package.module.exports.Package.activateNow (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:232:19)"
+          detail = "TypeError: Cannot read property 'command' of undefined"
+          message = "Failed to activate the broken-activation package"
+          atom.notifications.addFatalError(message, {stack, detail, dismissable: true})
+          notificationContainer = workspaceElement.querySelector('atom-notifications')
+          fatalError = notificationContainer.querySelector('atom-notification.fatal')
+
+        it "displays a fatal error with the package name in the error", ->
+          waitsForPromise ->
+            fatalError.getRenderPromise()
+
+          runs ->
+            expect(notificationContainer.childNodes.length).toBe 1
+            expect(fatalError).toHaveClass 'has-close'
+            expect(fatalError.innerHTML).toContain "TypeError: Cannot read property 'command' of undefined"
+            expect(fatalError.innerHTML).toContain "<a href=\"https://github.com/atom/notifications\">broken-activation package</a>"
+            expect(fatalError.issue.getPackageName()).toBe 'broken-activation'
+
       describe "when an exception is thrown from a package without a trace, but with a URL", ->
         beforeEach ->
           issueBody = null

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -433,7 +433,7 @@ describe "Notifications", ->
           stack = "TypeError: Cannot read property 'prototype' of undefined\n  at __extends (<anonymous>:1:1)\n  at Object.defineProperty.value [as .coffee] (/Applications/Atom.app/Contents/Resources/app.asar/src/compile-cache.js:169:21)"
           detail = "TypeError: Cannot read property 'prototype' of undefined"
           message = "Failed to load the broken-load package"
-          atom.notifications.addFatalError(message, {stack, detail, dismissable: true})
+          atom.notifications.addFatalError(message, {stack, detail, packageName: 'broken-load', dismissable: true})
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 
@@ -480,7 +480,7 @@ describe "Notifications", ->
                    ^^^^^
           """
           message = "Failed to load a language-broken-grammar package grammar"
-          atom.notifications.addFatalError(message, {stack, detail, dismissable: true})
+          atom.notifications.addFatalError(message, {stack, detail, packageName: 'language-broken-grammar', dismissable: true})
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 
@@ -514,7 +514,7 @@ describe "Notifications", ->
           stack = "TypeError: Cannot read property 'command' of undefined\n  at Object.module.exports.activate (<anonymous>:7:23)\n  at Package.module.exports.Package.activateNow (/Applications/Atom.app/Contents/Resources/app.asar/src/package.js:232:19)"
           detail = "TypeError: Cannot read property 'command' of undefined"
           message = "Failed to activate the broken-activation package"
-          atom.notifications.addFatalError(message, {stack, detail, dismissable: true})
+          atom.notifications.addFatalError(message, {stack, detail, packageName: 'broken-activation', dismissable: true})
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 


### PR DESCRIPTION
:warning: Sorta-kinda depends on atom/atom#9440, which has not been released yet :warning:

This fixes the following scenarios:
* A package fails to load and throws a "Failed to load the \<package\> package" error
* A package fails to activate and throws a "Failed to activate the \<package\> package" error
* A grammar fails to load and throws a "Failed to load a \<package\> package grammar" error
* A package that has been `apm link`ed on a Windows machine throws an error

All of those would previously fail to find the correct package to report the issue to and so they were all dumped to atom/atom.

Refs #66
Fixes #98