### PR TITLE
Wrap whole words in notification detail (#84)

### DIFF
--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -170,7 +170,6 @@ atom-notification {
     overflow-y: auto;
 
     .line {
-      white-space: pre;
       font-family: @font-family-monospace;
     }
 
@@ -182,8 +181,18 @@ atom-notification {
       }
     }
 
+    .detail-container {
+      .line {
+        white-space: pre-wrap;
+      }
+    }
+
     .stack-container {
       margin-top: @component-padding;
+
+      .line {
+        white-space: pre;
+      }
     }
   }
 


### PR DESCRIPTION
The detail message will be wrapped at word breaks while stack traces are still wrapped at the point where the space on the line runs out.

Wrapping stack traces the same way as the details looked a bit odd so I kept them unwrapped (hence the complex diff).

Here's a quick command to execute in the console for checking how things look:
```javascript
atom.notifications.addError("Test notification", {
  detail: "This is the detail string AND it is verylongandhasverylittlespaces. Again? This is the detail string AND it is verylongandhasverylittlespaces.",
  stack: new Error().stack + "\n    at MyObject.Foo.Bar.abc().qwertyuiop() (asdfghjkl-zxcvbnmyhn-qasdfghytrew.js:213:12)",
  dismissable: true
})
```