### PR TITLE
Don't assume filePath is non-empty

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -187,7 +187,7 @@ class NotificationIssue
         packagePaths[packageName] = fs.realpathSync(packagePath)
 
     getPackageName = (filePath) =>
-      filePath = /\((.+?):\d+|\((.+)\)|(.+)/.exec(filePath)[0]
+      filePath = /\((.+?):\d+|\((.+)\)|(.*)/.exec(filePath)[0]
 
       # Stack traces may be a file URI
       if match = FileURLRegExp.exec(filePath)


### PR DESCRIPTION
Looks like we don't even have the luxury of that.

Fixes #107.

Any tips on how to write specs for this?  I'm not sure how to make the file path empty.