### PR TITLE
Use https://git.io insead of http

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -42,7 +42,7 @@ class NotificationIssue
       @getIssueUrl().then (issueUrl) ->
         if UserUtilities.getPlatform() is 'win32'
           # win32 can only handle a 2048 length link, so we use the shortener.
-          $.ajax 'http://git.io',
+          $.ajax 'https://git.io',
             type: 'POST'
             data: url: issueUrl
             success: (data, status, xhr) ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -916,7 +916,7 @@ generateException = ->
 generateFakeAjaxResponses = (options) ->
   $.ajax.andCallFake (url, settings) ->
     if url.indexOf('git.io') > -1
-      response = options?.shortenerResponse ? ['--', '201', {getResponseHeader: -> 'http://git.io/cats'}]
+      response = options?.shortenerResponse ? ['--', '201', {getResponseHeader: -> 'https://git.io/cats'}]
       settings.success.apply(settings, response)
     else if url.indexOf('atom.io/api/packages') > -1
       response = options?.packageResponse ? {


### PR DESCRIPTION
git.io uses HTTPS.  Might prevent some console errors I was seeing about how `http://git.io` 503'd.