### PR TITLE
replace ATOM_HOME in issue title with generic placeholder

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -60,6 +60,7 @@ class NotificationIssue
 
   getIssueTitle: ->
     title = @notification.getMessage()
+    title = title.replace(process.env.ATOM_HOME, '$ATOM_HOME')
     if title.length > TITLE_CHAR_LIMIT
       title = title.substring(0, TITLE_CHAR_LIMIT - 3) + '...'
     title


### PR DESCRIPTION
I just ran into issue #25. The package `sync-settings` triggered an exception when updating to a newer version. Since the title of the issue contains a path to file within the `.atom` folder the title is different for every unique user name. See Hackafe/atom-sync-settings#194 (as well as Hackafe/atom-sync-settings#195, ..., Hackafe/atom-sync-settings#200, and probably more to come).

I don't see a good reason to embed a user specific path in the issue title. If the user specific path would be substituted with a generic placeholder those issues would have been considered to be the same. And no information for debugging the problem is lost in this substitution.