### PR TITLE
URL shortening, take 2

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -40,9 +40,12 @@ class NotificationIssue
   getIssueUrlForSystem: ->
     new Promise (resolve, reject) =>
       @getIssueUrl().then (issueUrl) ->
-        issueUrl = encodeURIComponent(issueUrl)
-        $.ajax "https://api-ssl.bitly.com/v3/shorten?access_token=04ffc90d972077e493f9958177db31410cb23973&format=json&longUrl=#{issueUrl}",
-          success: (data) -> resolve(data.data.url)
+        $.ajax "https://is.gd/create.php?format=simple",
+          type: 'POST'
+          data: url: issueUrl
+          success: (data) ->
+            console.log(data)
+            resolve(data)
           error: -> resolve(issueUrl)
       return
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -43,9 +43,7 @@ class NotificationIssue
         $.ajax "https://is.gd/create.php?format=simple",
           type: 'POST'
           data: url: issueUrl
-          success: (data) ->
-            console.log(data)
-            resolve(data)
+          success: (data) -> resolve(data)
           error: -> resolve(issueUrl)
       return
 

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -314,7 +314,7 @@ describe "Notifications", ->
 
             button = fatalError.querySelector('.btn')
             expect(button.textContent).toContain 'Create issue on the notifications package'
-            expect(button.getAttribute('href')).toContain 'bit.ly/cats'
+            expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
             expect(issueTitle).toContain '$ATOM_HOME'
             expect(issueTitle).not.toContain process.env.ATOM_HOME
@@ -583,7 +583,7 @@ describe "Notifications", ->
 
           button = fatalError.querySelector('.btn')
           expect(button.textContent).toContain 'Create issue on atom/atom'
-          expect(button.getAttribute('href')).toContain 'bit.ly/cats'
+          expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
           expect(issueBody).toContain 'ReferenceError: a is not defined'
           expect(issueBody).toContain '**Thrown From**: Atom Core'
@@ -622,7 +622,7 @@ describe "Notifications", ->
           fatalNotification = fatalError.querySelector('.fatal-notification')
           expect(button.textContent).toContain 'Create issue'
           expect(fatalNotification.textContent).toContain 'You can help by creating an issue'
-          expect(button.getAttribute('href')).toContain 'bit.ly/cats'
+          expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
       describe "when the error has not been reported", ->
         beforeEach ->
@@ -651,7 +651,7 @@ describe "Notifications", ->
               button = fatalError.querySelector('.btn')
               encodedMessage = encodeURI(truncatedMessage)
               expect(button.textContent).toContain 'Create issue'
-              expect(button.getAttribute('href')).toContain 'bit.ly/cats'
+              expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
       describe "when the package is out of date", ->
         beforeEach ->
@@ -875,10 +875,8 @@ generateException = ->
 # issuesResponse
 generateFakeAjaxResponses = (options) ->
   $.ajax.andCallFake (url, settings) ->
-    if url.indexOf('bitly.com') > -1
-      response = options?.shortenerResponse ? {
-        data: url: 'http://bit.ly/cats'
-      }
+    if url.indexOf('is.gd') > -1
+      response = options?.shortenerResponse ? 'http://is.gd/cats'
       settings.success(response)
     else if url.indexOf('atom.io/api/packages') > -1
       response = options?.packageResponse ? {


### PR DESCRIPTION
It turns out bit.ly didn’t like our URLs because they contain encoded newlines.