### PR TITLE
use package manager to get debug info instead of apm process

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "dependencies": {
     "fs-plus": "^2.6.0",
     "jquery": "^2",
+    "lodash": "^4.11.1",
     "marked": "^0.3.5",
     "semver": "^4.3.2",
     "stacktrace-parser": "^0.1.3",


### PR DESCRIPTION
fix for #103.

should have same output, and doesn't seem to freeze atom when fetching large package lists.