### PR TITLE
Shorter close animation

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -41,7 +41,7 @@ ButtonTemplate = """
 """
 
 class NotificationElement extends HTMLElement
-  animationDuration: 700
+  animationDuration: 360
   visibilityDuration: 5000
   fatalTemplate: TemplateHelper.create(FatalMetaNotificationTemplate)
   metaTemplate: TemplateHelper.create(MetaNotificationTemplate)

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -280,8 +280,8 @@ atom-notification {
 
   &.remove,
   &.remove:hover {
-    -webkit-animation: notification-hide   .24s      cubic-bezier(0.33859, -0.42, 1, -0.22),
-                       notification-shrink .24s .24s cubic-bezier(0.5, 0, 0, 1);
+    -webkit-animation: notification-hide   .12s      cubic-bezier(.34,.07,1,.2),
+                       notification-shrink .24s .12s cubic-bezier(0.5, 0, 0, 1);
     -webkit-animation-fill-mode: forwards;
   }
 }


### PR DESCRIPTION
Currently when clicking the close button, the animation bounces a bit before closing. That's cool and all, but maybe also annoying. This PR removes the bounce and reduces the animation duration.

:snail: Before | :rabbit: After
--- | ---
![close-before](https://cloud.githubusercontent.com/assets/378023/15315522/11405cfa-1c53-11e6-9d0c-84af433f2745.gif) | ![close](https://cloud.githubusercontent.com/assets/378023/15315529/18cef472-1c53-11e6-8b2d-a9b5b2280618.gif)

Closes #123