### PR TITLE
Ensure package names correctly id'ed on Win

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -69,7 +69,6 @@ class NotificationIssue
   getIssueBody: ->
     new Promise (resolve, reject) =>
       return resolve(@issueBody) if @issueBody
-
       systemPromise = UserUtilities.getOSVersion()
       installedPackagesPromise = UserUtilities.getInstalledPackages()
 
@@ -195,11 +194,13 @@ class NotificationIssue
       if match = FileURLRegExp.exec(filePath)
         filePath = match[1]
 
+      filePath = path.normalize(filePath)
+
       if path.isAbsolute(filePath)
         for packName, packagePath of packagePaths
           continue if filePath is 'node.js'
-          relativePath = path.relative(packagePath, filePath)
-          return packName unless /^\.\./.test(relativePath)
+          isSubfolder = filePath.indexOf(path.normalize(packagePath + path.sep)) is 0
+          return packName if isSubfolder
       @getPackageNameFromFilePath(filePath)
 
     if options.detail? and packageName = getPackageName(options.detail)


### PR DESCRIPTION
Tested on Windows and Mac OS X.

New tip: Path.Relative can't always make a relative path on Windows. You can't relatively move from one drive to another. There are multiple absolutes unlike Mac/Windows where you can always ../ up to root and go down another mount.