### PR TITLE
Electron version

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -99,9 +99,6 @@ class NotificationIssue
         atomVersion = atom.getVersion()
         electronVersion = process.versions.electron
 
-        if atom.getLoadSettings().apiPreviewMode
-          atomVersion += " :warning: **in 1.0 API Preview Mode** :warning:"
-
         @issueBody = """
           [Enter steps to reproduce below:]
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -97,6 +97,8 @@ class NotificationIssue
           packageMessage = 'Atom Core'
 
         atomVersion = atom.getVersion()
+        electronVersion = process.versions.electron
+
         if atom.getLoadSettings().apiPreviewMode
           atomVersion += " :warning: **in 1.0 API Preview Mode** :warning:"
 
@@ -107,6 +109,7 @@ class NotificationIssue
           2. ...
 
           **Atom Version**: #{atomVersion}
+          **Electron Version**: #{electronVersion}
           **System**: #{systemName}
           **Thrown From**: #{packageMessage}
           #{rootUserStatus}


### PR DESCRIPTION
Add Electron version to diagnostic information so that we can see if people are building from a non-standard version of Electron.