### PR TITLE
Payload reduction for issue creation

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -40,6 +40,8 @@ class NotificationIssue
       .catch (e) -> null
 
   getIssueUrlForSystem: ->
+    # Windows will not launch URLs greater than ~2000 bytes so we need to shrink it
+    # Also is.gd has a limit of 5000 bytes...
     @getIssueUrl().then (issueUrl) ->
       fetch "https://is.gd/create.php?format=simple", {
         method: 'POST',
@@ -99,13 +101,13 @@ class NotificationIssue
         electronVersion = process.versions.electron
 
         @issueBody = """
-          [Enter steps to reproduce below:]
+          [Enter steps to reproduce:]
 
           1. ...
           2. ...
 
-          **Atom Version**: #{atomVersion}
-          **Electron Version**: #{electronVersion}
+          **Atom**: #{atomVersion}
+          **Electron**: #{electronVersion}
           **System**: #{systemName}
           **Thrown From**: #{packageMessage}
           #{rootUserStatus}

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -89,9 +89,9 @@ class NotificationIssue
           rootUserStatus = '**User**: root'
 
         if packageName? and repoUrl?
-          packageMessage = "[#{packageName}](#{repoUrl}) package, v#{packageVersion}"
+          packageMessage = "[#{packageName}](#{repoUrl}) package #{packageVersion}"
         else if packageName?
-          packageMessage = "'#{packageName}' package, v#{packageVersion}"
+          packageMessage = "'#{packageName}' package v#{packageVersion}"
         else
           packageMessage = 'Atom Core'
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -81,7 +81,6 @@ class NotificationIssue
         repoUrl = @getRepoUrl()
         packageName = @getPackageName()
         packageVersion = atom.packages.getLoadedPackage(packageName)?.metadata?.version if packageName?
-        userConfig = UserUtilities.getConfigForPackage(packageName)
         copyText = ''
         systemUser = process.env.USER
         rootUserStatus = ''
@@ -124,12 +123,6 @@ class NotificationIssue
           ### Commands
 
           #{CommandLogger.instance().getText()}
-
-          ### Config
-
-          ```json
-          #{JSON.stringify(userConfig, null, 2)}
-          ```
 
           ### Installed Packages
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -26,8 +26,8 @@ class NotificationIssue
     query = "#{issueTitle} repo:#{repo}"
 
     fetch "https://api.github.com/search/issues?q=#{encodeURIComponent(query)}&sort=created", {headers: githubHeaders}
-      .then (r) => r?.json()
-      .then (data) =>
+      .then (r) -> r?.json()
+      .then (data) ->
         if data?.items?
           issues = {}
           for issue in data.items
@@ -45,7 +45,7 @@ class NotificationIssue
     @getIssueUrl().then (issueUrl) ->
       fetch "https://is.gd/create.php?format=simple", {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        headers: {'Content-Type': 'application/x-www-form-urlencoded'},
         body: "url=#{encodeURIComponent(issueUrl)}"
       }
       .then (r) -> r.text()

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -105,7 +105,7 @@ module.exports =
   isDevModePackagePath: (packagePath) ->
     packagePath.match(DEV_PACKAGE_PATH)?
 
-  # Returns a promise. Resolves with object of arrays {dev: ['some-package, v0.2.3', ...], user: [...]}
+  # Returns a promise. Resolves with object of arrays {dev: ['some-package 0.2.3', ...], user: [...]}
   getInstalledPackages: ->
     new Promise (resolve, reject) =>
       devPackagePaths = atom.packages.getAvailablePackagePaths().filter(@isDevModePackagePath)
@@ -124,9 +124,9 @@ module.exports =
 
   getPackageNames: (availablePackages, devPackageNames, activePackageNames, devMode) ->
     if devMode
-      "#{pack.name}, v#{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name in devPackageNames
+      "#{pack.name} #{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name in devPackageNames
     else
-      "#{pack.name}, v#{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name not in devPackageNames
+      "#{pack.name} #{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name not in devPackageNames
 
   getLatestAtomData: ->
     fetch 'https://atom.io/api/updates', {headers: githubHeaders}

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -36,7 +36,7 @@ module.exports =
 
   macVersionText: ->
     @macVersionInfo().then (info) ->
-      return 'Unknown OS X version' unless info.ProductName and info.ProductVersion
+      return 'Unknown macOS version' unless info.ProductName and info.ProductVersion
       "#{info.ProductName} #{info.ProductVersion}"
 
   macVersionInfo: ->
@@ -91,42 +91,22 @@ module.exports =
         stdout: (oneLine) -> data.push(oneLine)
         exit: ->
           info = data.join('\n')
-          info = if (res = /OS.Name.\s+(.*)$/im.exec(info)) then res[1] else 'Unknown Windows Version'
+          info = if (res = /OS.Name.\s+(.*)$/im.exec(info)) then res[1] else 'Unknown Windows version'
           resolve(info)
 
       systemInfo.onWillThrowError ({handle}) ->
         handle()
-        resolve('Unknown Windows Version')
+        resolve('Unknown Windows version')
 
   ###
   Section: Installed Packages
   ###
 
-  isDevModePackagePath: (packagePath) ->
-    packagePath.match(DEV_PACKAGE_PATH)?
-
-  # Returns a promise. Resolves with object of arrays {dev: ['some-package 0.2.3', ...], user: [...]}
-  getInstalledPackages: ->
+  getNonCorePackages: ->
     new Promise (resolve, reject) =>
-      devPackagePaths = atom.packages.getAvailablePackagePaths().filter(@isDevModePackagePath)
-      devPackageNames = devPackagePaths.map((packagePath) -> path.basename(packagePath))
-      availablePackages = atom.packages.getAvailablePackageMetadata()
-      activePackageNames = atom.packages.getActivePackages().map((activePackage) -> activePackage.name)
-      resolve
-        dev: @getPackageNames(availablePackages, devPackageNames, activePackageNames, true)
-        user: @getPackageNames(availablePackages, devPackageNames, activePackageNames, false)
-
-  getActiveLabel: (packageName, activePackageNames) ->
-    if packageName in activePackageNames
-      'active'
-    else
-      'inactive'
-
-  getPackageNames: (availablePackages, devPackageNames, activePackageNames, devMode) ->
-    if devMode
-      "#{pack.name} #{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name in devPackageNames
-    else
-      "#{pack.name} #{pack.version} (#{@getActiveLabel(pack.name, activePackageNames)})" for pack in (availablePackages ? []) when pack.name not in devPackageNames
+      nonCorePackages = atom.packages.getAvailablePackageMetadata().filter((p) -> !atom.packages.isBundledPackage(p.name))
+      devPackageNames = atom.packages.getAvailablePackagePaths().filter((p) -> p.includes(DEV_PACKAGE_PATH)).map((p) => path.basename(p))
+      resolve("#{pack.name} #{pack.version} #{if pack.name in devPackageNames then '(dev)' else ''}" for pack in nonCorePackages)
 
   getLatestAtomData: ->
     fetch 'https://atom.io/api/updates', {headers: githubHeaders}

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -99,18 +99,6 @@ module.exports =
         resolve('Unknown Windows Version')
 
   ###
-  Section: Config Values
-  ###
-
-  getConfigForPackage: (packageName) ->
-    config = core: atom.config.settings.core
-    if packageName?
-      config[packageName] = atom.config.settings[packageName]
-    else
-      config.editor = atom.config.settings.editor
-    config
-
-  ###
   Section: Installed Packages
   ###
 

--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -103,9 +103,9 @@ module.exports =
   ###
 
   getNonCorePackages: ->
-    new Promise (resolve, reject) =>
-      nonCorePackages = atom.packages.getAvailablePackageMetadata().filter((p) -> !atom.packages.isBundledPackage(p.name))
-      devPackageNames = atom.packages.getAvailablePackagePaths().filter((p) -> p.includes(DEV_PACKAGE_PATH)).map((p) => path.basename(p))
+    new Promise (resolve, reject) ->
+      nonCorePackages = atom.packages.getAvailablePackageMetadata().filter((p) -> not atom.packages.isBundledPackage(p.name))
+      devPackageNames = atom.packages.getAvailablePackagePaths().filter((p) -> p.includes(DEV_PACKAGE_PATH)).map((p) -> path.basename(p))
       resolve("#{pack.name} #{pack.version} #{if pack.name in devPackageNames then '(dev)' else ''}" for pack in nonCorePackages)
 
   getLatestAtomData: ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -327,16 +327,6 @@ describe "Notifications", ->
             # FIXME: this doesnt work on the test server. `apm ls` is not working for some reason.
             # expect(issueBody).toContain 'notifications, v'
 
-        it "contains core and notifications config values", ->
-          atom.config.set('notifications.something', 10)
-          waitsForPromise ->
-            fatalError.getRenderPromise().then -> issueBody = fatalError.issue.issueBody
-
-          runs ->
-            expect(issueBody).toContain '"core":'
-            expect(issueBody).toContain '"notifications":'
-            expect(issueBody).not.toContain '"editor":'
-
         it "standardizes platform separators on #win32", ->
           waitsForPromise ->
             fatalError.getRenderPromise().then ->
@@ -625,11 +615,6 @@ describe "Notifications", ->
 
           expect(issueBody).toContain 'ReferenceError: a is not defined'
           expect(issueBody).toContain '**Thrown From**: Atom Core'
-
-        it "contains core and editor config values", ->
-          expect(issueBody).toContain '"core":'
-          expect(issueBody).toContain '"editor":'
-          expect(issueBody).not.toContain '"notifications":'
 
         it "contains the commands that the user run in the issue body", ->
           expect(issueBody).toContain 'some-package:a-command'

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -321,11 +321,11 @@ describe "Notifications", ->
             expect(issueBody).toMatch /Atom Version\*\*: [0-9].[0-9]+.[0-9]+/ig
             expect(issueBody).not.toMatch /Unknown/ig
             expect(issueBody).toContain 'ReferenceError: a is not defined'
-            expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package, v'
+            expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package '
             expect(issueBody).toContain '# User'
 
             # FIXME: this doesnt work on the test server. `apm ls` is not working for some reason.
-            # expect(issueBody).toContain 'notifications, v'
+            # expect(issueBody).toContain 'notifications '
 
         it "standardizes platform separators on #win32", ->
           waitsForPromise ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -303,7 +303,8 @@ describe "Notifications", ->
           waitsForPromise ->
             fatalError.getRenderPromise().then ->
               issueTitle = fatalError.issue.getIssueTitle()
-              issueBody = fatalError.issue.issueBody
+              fatalError.issue.getIssueBody().then (result) ->
+                issueBody = result
 
           runs ->
             expect(notificationContainer.childNodes.length).toBe 1
@@ -314,7 +315,6 @@ describe "Notifications", ->
 
             button = fatalError.querySelector('.btn')
             expect(button.textContent).toContain 'Create issue on the notifications package'
-            expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
             expect(issueTitle).toContain '$ATOM_HOME'
             expect(issueTitle).not.toContain process.env.ATOM_HOME
@@ -599,7 +599,9 @@ describe "Notifications", ->
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
           waitsForPromise ->
-            fatalError.getRenderPromise().then -> issueBody = fatalError.issue.issueBody
+            fatalError.getRenderPromise().then ->
+              fatalError.issue.getIssueBody().then (result) ->
+                issueBody = result
 
         it "displays a fatal error with the package name in the error", ->
           expect(notificationContainer.childNodes.length).toBe 1
@@ -611,7 +613,6 @@ describe "Notifications", ->
 
           button = fatalError.querySelector('.btn')
           expect(button.textContent).toContain 'Create issue on atom/atom'
-          expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
           expect(issueBody).toContain 'ReferenceError: a is not defined'
           expect(issueBody).toContain '**Thrown From**: Atom Core'
@@ -645,7 +646,6 @@ describe "Notifications", ->
           fatalNotification = fatalError.querySelector('.fatal-notification')
           expect(button.textContent).toContain 'Create issue'
           expect(fatalNotification.textContent).toContain 'You can help by creating an issue'
-          expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
       describe "when the error has not been reported", ->
         beforeEach ->
@@ -674,7 +674,6 @@ describe "Notifications", ->
               button = fatalError.querySelector('.btn')
               encodedMessage = encodeURIComponent(truncatedMessage)
               expect(button.textContent).toContain 'Create issue'
-              expect(button.getAttribute('href')).toContain 'is.gd/cats'
 
       describe "when the package is out of date", ->
         beforeEach ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -318,7 +318,7 @@ describe "Notifications", ->
 
             expect(issueTitle).toContain '$ATOM_HOME'
             expect(issueTitle).not.toContain process.env.ATOM_HOME
-            expect(issueBody).toMatch /Atom Version\*\*: [0-9].[0-9]+.[0-9]+/ig
+            expect(issueBody).toMatch /Atom\*\*: [0-9].[0-9]+.[0-9]+/ig
             expect(issueBody).not.toMatch /Unknown/ig
             expect(issueBody).toContain 'ReferenceError: a is not defined'
             expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package '

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -322,7 +322,7 @@ describe "Notifications", ->
             expect(issueBody).not.toMatch /Unknown/ig
             expect(issueBody).toContain 'ReferenceError: a is not defined'
             expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package '
-            expect(issueBody).toContain '# User'
+            expect(issueBody).toContain '### Non-Core Packages'
 
             # FIXME: this doesnt work on the test server. `apm ls` is not working for some reason.
             # expect(issueBody).toContain 'notifications '

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -895,8 +895,8 @@ generateException = ->
 # shortenerResponse
 # packageResponse
 # issuesResponse
-generateFakeFetchResponses = (options) =>
-  fetch.andCallFake (url) =>
+generateFakeFetchResponses = (options) ->
+  fetch.andCallFake (url) ->
     if url.indexOf('is.gd') > -1
       return textPromise options?.shortenerResponse ? 'http://is.gd/cats'
 

--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -211,6 +211,10 @@ atom-notification {
   .btn-copy-report {
     vertical-align: middle;
   }
+
+  .opening {
+    cursor: progress;
+  }
 }
 
 // Types -------------------------------


### PR DESCRIPTION
When we create an issue we need to craft a very long URL to fill in the template.  Windows has limits on executing a URL to another process so we post it to is.gd to create a shorturl.

Lately however we have exceeded the maximum URL size of shorturl so have removed the userconfig and the full packages list.

We now send only non-core packages names/versions and have a few other minor tweaks to the template and encoding to reduce the size of the encoded url sent to is.gd.

On systems with many packages installed we will still exceed the limit. Will consider auto-truncating the text.

Fixes #132 #129 