### PR TITLE
Protect against an undefined command target

### DIFF
--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -81,9 +81,9 @@ class CommandLogger
       @logIndex = (@logIndex + 1) % @logSize
       event = @latestEvent()
       event.name = name
-      event.targetNodeName = target.nodeName
-      event.targetClassName = target.className
-      event.targetId = target.id
+      event.targetNodeName = target?.nodeName
+      event.targetClassName = target?.className
+      event.targetId = target?.id
       event.count = 1
       event.time = time ? Date.now()
 


### PR DESCRIPTION
### Description of the Change

Protects against an `undefined` command target in the `CommandLogger`.

### Alternate Designs

* Considered fixing bug that was causing `target` to be `undefined` but figured that this code should be more flexible than that

### Benefits

* Prevents uncaught exceptions like in #135

### Possible Drawbacks

* Doesn't address how something is calling a command on an `undefined` target

### Applicable Issues

Fixes #135
