### PR TITLE
Leading-trim and normalize the paths

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -1,4 +1,4 @@
-fs = require 'fs'
+fs = require 'fs-plus'
 path = require 'path'
 StackTraceParser = require 'stacktrace-parser'
 
@@ -140,8 +140,16 @@ class NotificationIssue
         """
         resolve(@issueBody)
 
-  normalizedStackPaths: (stack) ->
-    stack.replace /(^\W+at )([\w.]{2,} [(])?(.*)(:\d+:\d+[)]?)/gm, (m, p1, p2, p3, p4) -> p1 + (p2 || '') + p3.replace(/\\/g, '/').replace(/.*(\/(app\.asar|packages\/).*)/, '$1') + p4
+  normalizedStackPaths: (stack) =>
+    stack.replace /(^\W+at )([\w.]{2,} [(])?(.*)(:\d+:\d+[)]?)/gm, (m, p1, p2, p3, p4) => p1 + (p2 || '') +
+      @normalizePath(p3) + p4
+
+  normalizePath: (path) ->
+    path.replace('file:///', '')                         # Randomly inserted file url protocols
+        .replace(/[/]/g, '\\')                           # Temp switch for Windows home matching
+        .replace(fs.getHomeDirectory(), '~')             # Remove users home dir for apm-dev'ed packages
+        .replace(/\\/g, '/')                             # Switch \ back to / for everyone
+        .replace(/.*(\/(app\.asar|packages\/).*)/, '$1') # Remove everything before app.asar or pacakges
 
   getRepoUrl: ->
     packageName = @getPackageName()

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -123,7 +123,7 @@ class NotificationIssue
           ```
           At #{options.detail}
 
-          #{options.stack}
+          #{@normalizedStackPaths(options.stack)}
           ```
 
           ### Commands
@@ -139,6 +139,9 @@ class NotificationIssue
           #{copyText}
         """
         resolve(@issueBody)
+
+  normalizedStackPaths: (stack) ->
+    stack.replace /(^\W+at )([\w.]{2,} [(])?(.*)(:\d+:\d+[)]?)/gm, (m, p1, p2, p3, p4) -> p1 + (p2 || '') + p3.replace(/\\/g, '/').replace(/.*(\/(app\.asar|packages\/).*)/, '$1') + p4
 
   getRepoUrl: ->
     packageName = @getPackageName()

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -141,7 +141,7 @@ class NotificationIssue
         resolve(@issueBody)
 
   normalizedStackPaths: (stack) =>
-    stack.replace /(^\W+at )([\w.]{2,} [(])?(.*)(:\d+:\d+[)]?)/gm, (m, p1, p2, p3, p4) => p1 + (p2 || '') +
+    stack.replace /(^\W+at )([\w.]{2,} [(])?(.*)(:\d+:\d+[)]?)/gm, (m, p1, p2, p3, p4) => p1 + (p2 or '') +
       @normalizePath(p3) + p4
 
   normalizePath: (path) ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -281,7 +281,7 @@ describe "Notifications", ->
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 
-          spyOn(require('fs'), 'realpathSync').andCallFake (p) -> p
+          spyOn(fs, 'realpathSync').andCallFake (p) -> p
           spyOn(fatalError.issue, 'getPackagePathsByPackageName').andCallFake ->
             'save-session': '/Users/someguy/.atom/packages/save-session'
             'tabs': '/Applications/Atom.app/Contents/Resources/app/node_modules/tabs'


### PR DESCRIPTION
This cleans up the paths in order to;

a. Give us some more space on the is.gd payload
b. Make issues shorter and easier to read
c. Get usernames out of most stack traces (exception is those that are 

# After

```
ReferenceError: sdfsdf is not defined
    at Object.activate (~/github/exception-reporting/lib/main.js:43:5)
    at Package.module.exports.Package.activateNow (/app.asar/src/package.js:218:19)
    at /app.asar/src/package.js:190:32
    at Package.module.exports.Package.measure (/app.asar/src/package.js:96:15)
    at /app.asar/src/package.js:183:26
    at Package.module.exports.Package.activate (/app.asar/src/package.js:180:34)
    at PackageManager.module.exports.PackageManager.activatePackage (/app.asar/src/package-manager.js:550:34)
    at /app.asar/src/package-manager.js:531:29
    at Config.module.exports.Config.transactAsync (/app.asar/src/config.js:337:18)
    at PackageManager.module.exports.PackageManager.activatePackages (/app.asar/src/package-manager.js:526:19)
    at PackageManager.module.exports.PackageManager.activate (/app.asar/src/package-manager.js:508:46)
    at /app.asar/src/atom-environment.js:814:28
```

# Before

```
ReferenceError: sdfsdf is not defined
    at Object.activate (file:///C:/Users/damie/github/exception-reporting/lib/main.js:43:5)
    at Package.module.exports.Package.activateNow (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package.js:218:19)
    at C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package.js:190:32
    at Package.module.exports.Package.measure (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package.js:96:15)
    at C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package.js:183:26
    at Package.module.exports.Package.activate (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package.js:180:34)
    at PackageManager.module.exports.PackageManager.activatePackage (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package-manager.js:550:34)
    at C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package-manager.js:531:29
    at Config.module.exports.Config.transactAsync (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\config.js:337:18)
    at PackageManager.module.exports.PackageManager.activatePackages (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package-manager.js:526:19)
    at PackageManager.module.exports.PackageManager.activate (C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\package-manager.js:508:46)
    at C:\Users\damie\AppData\Local\Atom x64\app-dev\resources\app.asar\src\atom-environment.js:814:28
```