### PR TITLE
Adding fix for bug with having new lines as part of title.

### DIFF
--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -60,8 +60,11 @@ class NotificationIssue
     encodeURI(str).replace(/#/g, '%23').replace(/;/g, '%3B').replace(/%20/g, '+')
 
   getIssueTitle: ->
+    offset = 3
     title = @notification.getMessage()
     title = title.replace(process.env.ATOM_HOME, '$ATOM_HOME')
+    offset = 4 if title.indexOf('\n') > -1
+    title = title.replace(/\r?\n|\r/g,"");
     if process.platform is 'win32'
       title = title.replace(process.env.USERPROFILE, '~')
       title = title.replace(path.sep, path.posix.sep) # Standardize issue titles
@@ -69,7 +72,7 @@ class NotificationIssue
       title = title.replace(process.env.HOME, '~')
 
     if title.length > TITLE_CHAR_LIMIT
-      title = title.substring(0, TITLE_CHAR_LIMIT - 3) + '...'
+      title = title.substring(0, TITLE_CHAR_LIMIT - offset) + '...'
     title
 
   getIssueBody: ->

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -60,11 +60,8 @@ class NotificationIssue
     encodeURI(str).replace(/#/g, '%23').replace(/;/g, '%3B').replace(/%20/g, '+')
 
   getIssueTitle: ->
-    offset = 3
     title = @notification.getMessage()
     title = title.replace(process.env.ATOM_HOME, '$ATOM_HOME')
-    offset = 4 if title.indexOf('\n') > -1
-    title = title.replace(/\r?\n|\r/g,"");
     if process.platform is 'win32'
       title = title.replace(process.env.USERPROFILE, '~')
       title = title.replace(path.sep, path.posix.sep) # Standardize issue titles
@@ -72,8 +69,8 @@ class NotificationIssue
       title = title.replace(process.env.HOME, '~')
 
     if title.length > TITLE_CHAR_LIMIT
-      title = title.substring(0, TITLE_CHAR_LIMIT - offset) + '...'
-    title
+      title = title.substring(0, TITLE_CHAR_LIMIT - 3) + '...'
+    title.replace(/\r?\n|\r/g,"");
 
   getIssueBody: ->
     new Promise (resolve, reject) =>

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -70,7 +70,7 @@ class NotificationIssue
 
     if title.length > TITLE_CHAR_LIMIT
       title = title.substring(0, TITLE_CHAR_LIMIT - 3) + '...'
-    title.replace(/\r?\n|\r/g,"");
+    title.replace(/\r?\n|\r/g, "");
 
   getIssueBody: ->
     new Promise (resolve, reject) =>

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -70,7 +70,7 @@ class NotificationIssue
 
     if title.length > TITLE_CHAR_LIMIT
       title = title.substring(0, TITLE_CHAR_LIMIT - 3) + '...'
-    title.replace(/\r?\n|\r/g, "");
+    title.replace(/\r?\n|\r/g, "")
 
   getIssueBody: ->
     new Promise (resolve, reject) =>

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -263,29 +263,22 @@ describe "Notifications", ->
 
           runs ->
             expect(atom.notifications.getNotifications().length).toBe 0
-      describe "when an exception contains newline", ->
-        beforeEach ->
-          stack = """
-            TypeError: undefined is not a function
-              at Object.module.exports.Pane.promptToSaveItem [as defaultSavePrompt] (/Applications/Atom.app/Contents/Resources/app/src/pane.js:490:23)
-              at Pane.promptToSaveItem (/Users/someguy/.atom/packages/save-session/lib/save-prompt.coffee:21:15)
-              at Pane.module.exports.Pane.destroyItem (/Applications/Atom.app/Contents/Resources/app/src/pane.js:442:18)
-              at HTMLDivElement.<anonymous> (/Applications/Atom.app/Contents/Resources/app/node_modules/tabs/lib/tab-bar-view.js:174:22)
-              at space-pen-ul.jQuery.event.dispatch (/Applications/Atom.app/Contents/Resources/app/node_modules/archive-view/node_modules/atom-space-pen-views/node_modules/space-pen/vendor/jquery.js:4676:9)
-              at space-pen-ul.elemData.handle (/Applications/Atom.app/Contents/Resources/app/node_modules/archive-view/node_modules/atom-space-pen-views/node_modules/space-pen/vendor/jquery.js:4360:46)
-          """
-          detail = 'ok'
 
-          atom.notifications.addFatalError(stack, {detail, stack})
+      describe "when the message contains a newline", ->
+        beforeEach ->
+          message = "Uncaught Error: Cannot read property 'object' of undefined\nTypeError: Cannot read property 'object' of undefined"
+
+          atom.notifications.addFatalError(message)
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
-        it "title doesn't contain newline", ->
+
+        it "removes the newline when generating the issue title", ->
           waitsForPromise ->
             fatalError.getRenderPromise().then ->
               issueTitle = fatalError.issue.getIssueTitle()
           runs ->
             expect(issueTitle).not.toContain "\n"
-            expect(issueTitle).toBe "TypeError: undefined is not a function  at Object.module.exports.Pane.promptToSaveItem [as defau..."
+            expect(issueTitle).toBe "Uncaught Error: Cannot read property 'object' of undefinedTypeError: Cannot read property 'objec..."
 
       describe "when there are multiple packages in the stack trace", ->
         beforeEach ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -263,6 +263,28 @@ describe "Notifications", ->
 
           runs ->
             expect(atom.notifications.getNotifications().length).toBe 0
+      describe "when an exception contains newline", ->
+        beforeEach ->
+          stack = """
+            TypeError: undefined is not a function
+              at Object.module.exports.Pane.promptToSaveItem [as defaultSavePrompt] (/Applications/Atom.app/Contents/Resources/app/src/pane.js:490:23)
+              at Pane.promptToSaveItem (/Users/someguy/.atom/packages/save-session/lib/save-prompt.coffee:21:15)
+              at Pane.module.exports.Pane.destroyItem (/Applications/Atom.app/Contents/Resources/app/src/pane.js:442:18)
+              at HTMLDivElement.<anonymous> (/Applications/Atom.app/Contents/Resources/app/node_modules/tabs/lib/tab-bar-view.js:174:22)
+              at space-pen-ul.jQuery.event.dispatch (/Applications/Atom.app/Contents/Resources/app/node_modules/archive-view/node_modules/atom-space-pen-views/node_modules/space-pen/vendor/jquery.js:4676:9)
+              at space-pen-ul.elemData.handle (/Applications/Atom.app/Contents/Resources/app/node_modules/archive-view/node_modules/atom-space-pen-views/node_modules/space-pen/vendor/jquery.js:4360:46)
+          """
+          detail = 'ok'
+
+          atom.notifications.addFatalError(stack, {detail, stack})
+          notificationContainer = workspaceElement.querySelector('atom-notifications')
+          fatalError = notificationContainer.querySelector('atom-notification.fatal')
+        it "title doesn't contain newline", ->
+          waitsForPromise ->
+            fatalError.getRenderPromise().then ->
+              issueTitle = fatalError.issue.getIssueTitle()
+          runs ->
+            expect(issueTitle).not.toContain "\n"
 
       describe "when there are multiple packages in the stack trace", ->
         beforeEach ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -265,14 +265,12 @@ describe "Notifications", ->
             expect(atom.notifications.getNotifications().length).toBe 0
 
       describe "when the message contains a newline", ->
-        beforeEach ->
+        it "removes the newline when generating the issue title", ->
           message = "Uncaught Error: Cannot read property 'object' of undefined\nTypeError: Cannot read property 'object' of undefined"
-
           atom.notifications.addFatalError(message)
           notificationContainer = workspaceElement.querySelector('atom-notifications')
           fatalError = notificationContainer.querySelector('atom-notification.fatal')
 
-        it "removes the newline when generating the issue title", ->
           waitsForPromise ->
             fatalError.getRenderPromise().then ->
               issueTitle = fatalError.issue.getIssueTitle()

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -285,6 +285,7 @@ describe "Notifications", ->
               issueTitle = fatalError.issue.getIssueTitle()
           runs ->
             expect(issueTitle).not.toContain "\n"
+            expect(issueTitle).toBe "TypeError: undefined is not a function  at Object.module.exports.Pane.promptToSaveItem [as defau..."
 
       describe "when there are multiple packages in the stack trace", ->
         beforeEach ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -278,6 +278,19 @@ describe "Notifications", ->
             expect(issueTitle).not.toContain "\n"
             expect(issueTitle).toBe "Uncaught Error: Cannot read property 'object' of undefinedTypeError: Cannot read property 'objec..."
 
+      describe "when the message contains continguous newlines", ->
+        it "removes the newlines when generating the issue title", ->
+          message = "Uncaught Error: Cannot do the thing\n\nSuper sorry about this"
+          atom.notifications.addFatalError(message)
+          notificationContainer = workspaceElement.querySelector('atom-notifications')
+          fatalError = notificationContainer.querySelector('atom-notification.fatal')
+
+          waitsForPromise ->
+            fatalError.getRenderPromise().then ->
+              issueTitle = fatalError.issue.getIssueTitle()
+          runs ->
+            expect(issueTitle).toBe "Uncaught Error: Cannot do the thingSuper sorry about this"
+
       describe "when there are multiple packages in the stack trace", ->
         beforeEach ->
           stack = """


### PR DESCRIPTION
### Requirements


### Description of the Change
Error message with \n or new lines are being left out when it comes back from github api server.  

see https://api.github.com/search/issues?q=Uncaught%20Error%3A%20Cannot%20read%20property%20%27object%27%20of%20undefinedTypeError%3A%20Cannot%20read%20property%20%27objec...%20repo%3Aatom%2Fatom

the 

getIssueTitle() function doesn't escape newlines.


### Alternate Designs
Could just for escape newline in checking logic, but decided that having newline in title is a bit weird so opted to add it to getIssueTitle().

Seeing how existing issues already created with \n.  If we need to truncate the text, we would take into consider the \n as a character and add additional buffer.  

### Benefits
Titles in issues will look better going forward and people will stop the massive dup of issues that are created.

fixes #156 

### Possible Drawbacks

N/A

### Applicable Issues

#156 

/cc @as-cii @jasonrudolph @iolsen for feedback. 