### PR TITLE
Restore missing assertion in issue title truncation test

### DIFF
--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -699,8 +699,8 @@ describe "Notifications", ->
 
             runs ->
               button = fatalError.querySelector('.btn')
-              encodedMessage = encodeURIComponent(truncatedMessage)
               expect(button.textContent).toContain 'Create issue'
+              expect(fatalError.issue.getIssueTitle()).toBe(truncatedMessage)
 
       describe "when the package is out of date", ->
         beforeEach ->

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -680,7 +680,7 @@ describe "Notifications", ->
 
         describe "when the message is longer than 100 characters", ->
           message = "Uncaught Error: Cannot find module 'dialog'Error: Cannot find module 'dialog' at Function.Module._resolveFilename (module.js:351:15) at Function.Module._load (module.js:293:25) at Module.require (module.js:380:17) at EventEmitter.<anonymous> (/Applications/Atom.app/Contents/Resources/atom/browser/lib/rpc-server.js:128:79) at EventEmitter.emit (events.js:119:17) at EventEmitter.<anonymous> (/Applications/Atom.app/Contents/Resources/atom/browser/api/lib/web-contents.js:99:23) at EventEmitter.emit (events.js:119:17)"
-          truncatedMessage = "Uncaught Error: Cannot find module 'dialog'Error: Cannot find module 'dialog' at Function.Module...."
+          expectedIssueTitle = "Uncaught Error: Cannot find module 'dialog'Error: Cannot find module 'dialog' at Function.Module...."
 
           beforeEach ->
             generateFakeFetchResponses()
@@ -700,7 +700,7 @@ describe "Notifications", ->
             runs ->
               button = fatalError.querySelector('.btn')
               expect(button.textContent).toContain 'Create issue'
-              expect(fatalError.issue.getIssueTitle()).toBe(truncatedMessage)
+              expect(fatalError.issue.getIssueTitle()).toBe(expectedIssueTitle)
 
       describe "when the package is out of date", ->
         beforeEach ->


### PR DESCRIPTION
### Description of the Change

#76 added the logic to truncate issue titles to 100 characters, and it added a test to verify that logic. That test included [an assertion to verify the truncated issue title](https://github.com/atom/notifications/pull/76/files#diff-528cf05f3a4fc7b99c7849fa316f6aabR469).

#114 updated a handful of existing tests and happened to [remove the assertion that verified truncation of the issue title](https://github.com/atom/notifications/pull/114/files#diff-528cf05f3a4fc7b99c7849fa316f6aabL664).

Because that assertion was removed, it's currently possible to delete [the code that truncates the issue title](https://github.com/atom/notifications/blob/84f960142729a76d6715adabe7969681989e5fad/lib/notification-issue.coffee#L71-L72), and the [issue title truncation test](https://github.com/atom/notifications/blob/23d12428861b1b6ee0aed35bbe76d85a1843425e/spec/notifications-spec.coffee#L681-L703) will still pass. :grimacing:

This pull request updates the test to once again verify issue title truncation.

@joshaber: I suspect this particular removal in #114 was unintentional. Can you confirm that theory? (I realize that the PR shipped more than a year ago, so if you don't recall, I completely understand. :innocent:)

### Alternate Designs

None

### Benefits

Improve test coverage and reduce opportunity for regressions related to issue title generation

### Possible Drawbacks

None that I'm aware of

### Applicable Issues

/cc #76 #114
