### PR TITLE
More robustness for getting os version on Windows

### DIFF
--- a/lib/user-utilities.coffee
+++ b/lib/user-utilities.coffee
@@ -86,7 +86,7 @@ module.exports =
         stdout: (oneLine) -> data.push(oneLine)
         exit: ->
           info = data.join('\n')
-          info = if (res = /OS.Name.\s+(.*)$/im.exec(info)) then res[1] else 'Unknown Windows version'
+          info = if (res = /OS.+(Microsoft.+)$/im.exec(info)) then res[1] else 'Unknown Windows version'
           resolve(info)
 
       systemInfo.onWillThrowError ({handle}) ->


### PR DESCRIPTION
### Description of the Change

On Windows OS, if the system language is not English, type `systeminfo` in CMD would get "OS" with native chars instead of "OS Name". Change the regex statement to match "OS" with "Microsoft", so that `winVersionText` function can return useful version info on non-English system as well as English system. 

### Alternate Designs

None.

### Benefits

Get useful system version on non-English Windows OS instead of "Unknown Windows version".

### Possible Drawbacks

None.

### Applicable Issues

None.
