### PR TITLE
Include metadata in issue body when posting exception reports

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -40,6 +40,7 @@ Notifications =
         options =
           detail: "#{url}:#{line}"
           stack: originalError.stack
+          metadata: originalError.metadata
           dismissable: true
         atom.notifications.addFatalError(message, options)
 

--- a/lib/notification-issue.coffee
+++ b/lib/notification-issue.coffee
@@ -100,6 +100,17 @@ class NotificationIssue
         else
           packageMessage = 'Atom Core'
 
+        metadataSection = ""
+        if options.metadata
+          metadataSection = """
+
+            ### Metadata
+
+            ```json
+            #{JSON.stringify(options.metadata, null, 2)}
+            ```
+          """
+
         @issueBody = """
           [Enter steps to reproduce:]
 
@@ -121,6 +132,7 @@ class NotificationIssue
 
           #{@normalizedStackPaths(options.stack)}
           ```
+          #{metadataSection}
 
           ### Commands
 

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -350,6 +350,8 @@ describe "Notifications", ->
             expect(issueBody).toContain 'ReferenceError: a is not defined'
             expect(issueBody).toContain 'Thrown From**: [notifications](https://github.com/atom/notifications) package '
             expect(issueBody).toContain '### Non-Core Packages'
+            expect(issueBody).toContain '### Metadata'
+            expect(issueBody).toContain '{\n  "foo": "bar"\n}'
 
             # FIXME: this doesnt work on the test server. `apm ls` is not working for some reason.
             # expect(issueBody).toContain 'notifications '
@@ -916,6 +918,7 @@ generateException = ->
   try
     a + 1
   catch e
+    e.metadata = {foo: 'bar'}
     errMsg = "#{e.toString()} in #{process.env.ATOM_HOME}/somewhere"
     window.onerror.call(window, errMsg, '/dev/null', 2, 3, e)
 


### PR DESCRIPTION
This PR includes any optional metadata associated with an uncaught exception in the body of the issue, which may help us gather more information in manual exception reports. If a `.metadata` field is present on the exception, it is included in its own `### Metadata` section as a block of stringified JSON.