### PR TITLE
add padding to non-dismissable notification to avoid overlapping

### DIFF
--- a/styles/notifications.less
+++ b/styles/notifications.less
@@ -36,7 +36,7 @@ atom-notifications {
     .close-all {
       display: block;
     }
-    &.has-close .message {
+    .message {
       padding-right: @component-padding * 2 + 95px; // space for icon and button
     }
   }
@@ -44,6 +44,9 @@ atom-notifications {
   atom-notification:only-child {
     .close-all {
       display: none;
+    }
+    .message {
+      padding-right: inherit;
     }
     &.has-close .message {
       padding-right: @component-padding + 24px; // space for icon


### PR DESCRIPTION
### Description of the Change

- add padding for "Close All" button for notification satisfies
  - non-dismissable
  - first-child
  - not only-child (there are more than one notifications)
- also add selector in `:only-child` to apply original padding when only-one-notification of non-dismissable

### Benefits

fix overlap of non-dismissable notification

### Applicable Issues

#168
