### PR TITLE
Updating command.target to be an Object instead of String

### DIFF
--- a/lib/command-logger.coffee
+++ b/lib/command-logger.coffee
@@ -67,9 +67,10 @@ class CommandLogger
   #
   # * `command` Command {Object} to be logged
   #   * `type` Name {String} of the command
-  #   * `target` {String} describing where the command was triggered
+  #   * `target` {Object} Node where the command was triggered
   logCommand: (command) ->
-    {type: name, target, time} = command
+    {type: name, time} = command
+    target = command.target ? {}
     return if command.detail?.jQueryTrigger
     return if name of ignoredCommands
 


### PR DESCRIPTION
Probable fix for the below issue
https://github.com/atom/atom/issues/15639

We are accessing nodeName and className from target so it should ideally be an object. Added safe-check and initialize target to be an {}

### Requirements
Not a pro in coffeescript, need a simple check and default assignment to target as  {} 

### Description of the Change

Target should be an Object not the String

### Alternate Designs

Better way to handle the issue

### Benefits

https://github.com/atom/atom/issues/15639

### Possible Drawbacks

Not pro in coffeescript syntax

### Applicable Issues

https://github.com/atom/atom/issues/15639
