### PR TITLE
fix #45 - add option to turn off markdown

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -83,9 +83,14 @@ class NotificationElement
     @element.innerHTML = NotificationTemplate
 
     options = @model.getOptions()
+    options.contentType ||= 'text/markdown'
 
     notificationContainer = @element.querySelector('.message')
-    notificationContainer.innerHTML = marked(@model.getMessage())
+
+    if options.contentType is 'text/markdown'
+      notificationContainer.innerHTML = marked(@model.getMessage())
+    else if options.contentType is 'text/plain'
+      notificationContainer.innerHTML = @model.getMessage()
 
     if detail = @model.getDetail()
       addSplitLinesToContainer(@element.querySelector('.detail-content'), detail)

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -199,6 +199,23 @@ describe "Notifications", ->
         advanceClock(NotificationElement::animationDuration)
         expect(notificationContainer.childNodes.length).toBe 0
 
+    describe "when the `contentType` option is not used", ->
+      it "renders the notification text as markdown", ->
+        atom.notifications.addSuccess('# A message')
+        message = notificationContainer.querySelector('.message')
+        h1 = notificationContainer.querySelector('#a-message')
+        console.log message.childNodes
+        expect(message.childNodes.length).toBe 2
+        expect(h1.textContent.trim()).toBe 'A message'
+        expect(h1.nodeName).toBe 'H1'
+
+    describe "when the `contentType` option is set to `text/plain`", ->
+      it "renders the notification as plain text", ->
+        atom.notifications.addSuccess('# A message', contentType: 'text/plain')
+        message = notificationContainer.querySelector('.message')
+        expect(message.textContent.trim()).toBe '# A message'
+        expect(message.childNodes.length).toBe 1
+
     describe "when the `description` option is used", ->
       it "displays the description text in the .description element", ->
         atom.notifications.addSuccess('A message', description: 'This is [a link](http://atom.io)')


### PR DESCRIPTION
### Description of the Change

This commit allows renders the content message as plain text, not being necessary to escape markdown; Should we escape html ? I don't think so, since its `text/plain`. We may should add an option for text/html if necessary.

### Applicable Issues
#45 
