### PR TITLE
Clear log

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -64,7 +64,10 @@ Notifications =
     @subscriptions.add atom.workspace.addOpener (uri) => @createLog() if uri is NotificationsLog::getURI()
     @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:toggle-log', -> atom.workspace.toggle(NotificationsLog::getURI())
     @subscriptions.add atom.commands.add 'atom-workspace', 'notifications-plus:clear-log', =>
-      notification.dismiss() for notification in atom.notifications.getNotifications()
+      for notification in atom.notifications.getNotifications()
+        notification.options.dismissable = true
+        notification.dismissed = false
+        notification.dismiss()
       atom.notifications.clear()
       @notificationsLog?.clearLogItems() # TODO: remove this once atom/atom#16074 is released
 

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -63,6 +63,10 @@ Notifications =
     @addNotificationsLogSubscriptions() if @notificationsLog?
     @subscriptions.add atom.workspace.addOpener (uri) => @createLog() if uri is NotificationsLog::getURI()
     @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:toggle-log', -> atom.workspace.toggle(NotificationsLog::getURI())
+    @subscriptions.add atom.commands.add 'atom-workspace', 'notifications-plus:clear-log', =>
+      notification.dismiss() for notification in atom.notifications.getNotifications()
+      atom.notifications.clear()
+      @notificationsLog?.clearLogItems() # TODO: remove this once atom/atom#16074 is released
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -63,7 +63,7 @@ Notifications =
     @addNotificationsLogSubscriptions() if @notificationsLog?
     @subscriptions.add atom.workspace.addOpener (uri) => @createLog() if uri is NotificationsLog::getURI()
     @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:toggle-log', -> atom.workspace.toggle(NotificationsLog::getURI())
-    @subscriptions.add atom.commands.add 'atom-workspace', 'notifications-plus:clear-log', =>
+    @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:clear-log', =>
       for notification in atom.notifications.getNotifications()
         notification.options.dismissable = true
         notification.dismissed = false

--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -63,13 +63,12 @@ Notifications =
     @addNotificationsLogSubscriptions() if @notificationsLog?
     @subscriptions.add atom.workspace.addOpener (uri) => @createLog() if uri is NotificationsLog::getURI()
     @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:toggle-log', -> atom.workspace.toggle(NotificationsLog::getURI())
-    @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:clear-log', =>
+    @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:clear-log', ->
       for notification in atom.notifications.getNotifications()
         notification.options.dismissable = true
         notification.dismissed = false
         notification.dismiss()
       atom.notifications.clear()
-      @notificationsLog?.clearLogItems() # TODO: remove this once atom/atom#16074 is released
 
   deactivate: ->
     @subscriptions.dispose()

--- a/lib/notifications-log.coffee
+++ b/lib/notifications-log.coffee
@@ -50,7 +50,7 @@ module.exports = class NotificationsLog
 
     button = document.createElement('button')
     button.classList.add('notifications-clear-log', 'btn', 'icon', 'icon-dash')
-    button.addEventListener 'click', (e) -> atom.commands.dispatch(atom.views.getView(atom.workspace), "notifications-plus:clear-log")
+    button.addEventListener 'click', (e) -> atom.commands.dispatch(atom.views.getView(atom.workspace), "notifications:clear-log")
     @subscriptions.add atom.tooltips.add(button, {title: "Clear notifications"})
     header.appendChild(button)
 

--- a/lib/notifications-log.coffee
+++ b/lib/notifications-log.coffee
@@ -49,7 +49,7 @@ module.exports = class NotificationsLog
       header.appendChild(button)
 
     button = document.createElement('button')
-    button.classList.add('notifications-clear-log', 'btn', 'icon', 'icon-dash')
+    button.classList.add('notifications-clear-log', 'btn', 'icon', 'icon-trashcan')
     button.addEventListener 'click', (e) -> atom.commands.dispatch(atom.views.getView(atom.workspace), "notifications:clear-log")
     @subscriptions.add atom.tooltips.add(button, {title: "Clear notifications"})
     header.appendChild(button)

--- a/lib/notifications-log.coffee
+++ b/lib/notifications-log.coffee
@@ -22,7 +22,7 @@ module.exports = class NotificationsLog
     @typesHidden = typesHidden if typesHidden?
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
-    @subscriptions.add atom.notifications.onDidClearNotifications => @clear()
+    @subscriptions.add atom.notifications.onDidClearNotifications => @clearLogItems()
     @render()
     @subscriptions.add new Disposable => @clearLogItems()
 

--- a/lib/notifications-log.coffee
+++ b/lib/notifications-log.coffee
@@ -22,8 +22,7 @@ module.exports = class NotificationsLog
     @typesHidden = typesHidden if typesHidden?
     @emitter = new Emitter
     @subscriptions = new CompositeDisposable
-    # TODO: uncomment next line when atom/atom#16074 is released
-    # @subscriptions.add atom.notifications.onDidClearNotifications => @clear()
+    @subscriptions.add atom.notifications.onDidClearNotifications => @clear()
     @render()
     @subscriptions.add new Disposable => @clearLogItems()
 

--- a/spec/notifications-log-spec.coffee
+++ b/spec/notifications-log-spec.coffee
@@ -238,24 +238,16 @@ describe "Notifications Log", ->
     beforeEach ->
       clearButton = workspaceElement.querySelector('.notifications-log .notifications-clear-log')
       atom.notifications.addInfo('A message', dismissable: true)
+      atom.notifications.addInfo('non-dismissable')
       clearButton.click()
 
     it "clears the notifications", ->
       expect(atom.notifications.getNotifications()).toHaveLength 0
       notifications = workspaceElement.querySelector('atom-notifications')
       advanceClock(NotificationElement::animationDuration)
-      expect(notifications.childNodes).toHaveLength 0
+      expect(notifications.children).toHaveLength 0
       logItems = workspaceElement.querySelector('.notifications-log-items')
-      expect(logItems.childNodes).toHaveLength 0
-
-    # TODO: These don't work most likely because of some async operation
-    # it "removes all notifications", ->
-    #   notifications = workspaceElement.querySelector('atom-notifications')
-    #   expect(notifications.childNodes).toHaveLength 0
-    #
-    # it "clears the notifications log", ->
-    #   logItems = workspaceElement.querySelector('.notifications-log-items')
-    #   expect(logItems.childNodes).toHaveLength 0
+      expect(logItems.children).toHaveLength 0
 
   describe "the dock pane", ->
     notificationsLogPane = null

--- a/spec/notifications-log-spec.coffee
+++ b/spec/notifications-log-spec.coffee
@@ -233,6 +233,30 @@ describe "Notifications Log", ->
             expect(notification.dismissed).toBe true
             expect(notificationView.element).not.toBeVisible()
 
+  describe "when notifications are cleared", ->
+
+    beforeEach ->
+      clearButton = workspaceElement.querySelector('.notifications-log .notifications-clear-log')
+      atom.notifications.addInfo('A message', dismissable: true)
+      clearButton.click()
+
+    it "clears the notifications", ->
+      expect(atom.notifications.getNotifications()).toHaveLength 0
+      notifications = workspaceElement.querySelector('atom-notifications')
+      advanceClock(NotificationElement::animationDuration)
+      expect(notifications.childNodes).toHaveLength 0
+      logItems = workspaceElement.querySelector('.notifications-log-items')
+      expect(logItems.childNodes).toHaveLength 0
+
+    # TODO: These don't work most likely because of some async operation
+    # it "removes all notifications", ->
+    #   notifications = workspaceElement.querySelector('atom-notifications')
+    #   expect(notifications.childNodes).toHaveLength 0
+    #
+    # it "clears the notifications log", ->
+    #   logItems = workspaceElement.querySelector('.notifications-log-items')
+    #   expect(logItems.childNodes).toHaveLength 0
+
   describe "the dock pane", ->
     notificationsLogPane = null
 

--- a/styles/notifications-log.less
+++ b/styles/notifications-log.less
@@ -14,7 +14,7 @@
     background-color: @base-background-color;
     border-bottom: 1px solid @base-border-color;
 
-    .notification-type {
+    button {
       border: none;
       width: @icon-size;
       height: @icon-size;
@@ -23,6 +23,10 @@
       color: @text-color-subtle;
       opacity: .5;
       background: @base-background-color;
+    }
+
+    .notifications-clear-log {
+      float: right;
     }
   }
 


### PR DESCRIPTION
### Description of the Change

This adds a clear notifications button to the log

![image](https://user-images.githubusercontent.com/97994/33847378-e6937b64-de6f-11e7-8d31-bd209ae37235.png)

### Alternate Designs

At the moment the button clears the notifications with `atom.notifications.clear()` as well as clearing the log and any displayed notifications.

I would like to get it working with [`atom.notifications.onDidClearNotifications()`](https://github.com/atom/atom/pull/16074) once that gets released.

### Benefits

Ability to clear the notifications log

### Possible Drawbacks

none

### Applicable Issues

https://github.com/atom/notifications/pull/164#issuecomment-341341995