### PR TITLE
add default timeout setting

### DIFF
--- a/lib/main.coffee
+++ b/lib/main.coffee
@@ -47,6 +47,8 @@ Notifications =
     @subscriptions.add atom.commands.add 'atom-workspace', 'core:cancel', ->
       notification.dismiss() for notification in atom.notifications.getNotifications()
 
+    @subscriptions.add atom.config.observe 'notifications.defaultTimeout', (value) => @visibilityDuration = value
+
     if atom.inDevMode()
       @subscriptions.add atom.commands.add 'atom-workspace', 'notifications:trigger-error', ->
         try
@@ -78,7 +80,7 @@ Notifications =
     return if @isInitialized
 
     @subscriptions.add atom.views.addViewProvider Notification, (model) ->
-      new NotificationElement(model)
+      new NotificationElement(model, @visibilityDuration)
 
     @notificationsElement = document.createElement('atom-notifications')
     atom.views.getView(atom.workspace).appendChild(@notificationsElement)

--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -47,7 +47,7 @@ class NotificationElement
   visibilityDuration: 5000
   autohideTimeout: null
 
-  constructor: (@model) ->
+  constructor: (@model, @visibilityDuration) ->
     @fatalTemplate = TemplateHelper.create(FatalMetaNotificationTemplate)
     @metaTemplate = TemplateHelper.create(MetaNotificationTemplate)
     @buttonListTemplate = TemplateHelper.create(ButtonListTemplate)

--- a/package.json
+++ b/package.json
@@ -24,6 +24,12 @@
       "type": "boolean",
       "default": false,
       "description": "Show notifications for uncaught exceptions even if Atom is running in dev mode. If this config setting is disabled, uncaught exceptions will trigger the dev tools to open and be logged in the console tab."
+    },
+    "defaultTimeout": {
+      "type": "integer",
+      "default": 5000,
+      "minimum": 1000,
+      "description": "The default notification timeout for a non-dismissable notification."
     }
   },
   "deserializers": {

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -217,6 +217,19 @@ describe "Notifications", ->
           model.dismiss()
           expect(notification).toHaveClass 'remove'
 
+    describe "when the default timeout setting is changed", ->
+      [notification] = []
+
+      beforeEach ->
+        atom.config.set("notifications.defaultTimeout", 1000)
+        atom.notifications.addSuccess('A message')
+        notification = notificationContainer.querySelector('atom-notification.success')
+
+      it "uses the setting value for the autoclose timeout", ->
+        expect(notification).not.toHaveClass 'remove'
+        advanceClock(1000)
+        expect(notification).toHaveClass 'remove'
+
     describe "when the `description` option is used", ->
       it "displays the description text in the .description element", ->
         atom.notifications.addSuccess('A message', description: 'This is [a link](http://atom.io)')


### PR DESCRIPTION
### Description of the Change

Adds a setting so the user can change the default timeout of non-dismissable notifications.

The setting is an integer value in milliseconds.

It defaults to 5 seconds (5000ms) and can be set as low as 1 second (1000ms).

### Alternate Designs

We could change it to seconds instead of milliseconds

### Benefits

Some people might want the notification to go away quick since they can always open it back up from the notifications log, and some people might want to have more time to read the notifications.

### Possible Drawbacks

none

### Applicable Issues

none
