### PR TITLE
add allow popups setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,17 @@
       "default": 5000,
       "minimum": 1000,
       "description": "The default notification timeout for a non-dismissable notification."
+    },
+    "allowPopups": {
+      "type": "string",
+      "default": "All",
+      "description": "Allow popup notifications when a notification is received.",
+      "enum": [
+        "All",
+        "Errors",
+        "Dismissable",
+        "None"
+      ]
     }
   },
   "deserializers": {

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -951,3 +951,129 @@ describe "Notifications", ->
             notificationContainer = workspaceElement.querySelector('atom-notifications')
             error = notificationContainer.querySelector('atom-notification.fatal')
             expect(error).toExist()
+
+    describe "when the Allow Popups setting is set", ->
+
+      describe "when it is set to None", ->
+        beforeEach ->
+          atom.config.set('notifications.allowPopups', 'None')
+
+        it "will not display any notifications", ->
+          expect(notificationContainer.childNodes.length).toBe 0
+
+          notification = atom.notifications.addSuccess('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addSuccess('A message', dismissable: true)
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addInfo('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addWarning('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addError('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addFatalError('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+      describe "when it is set to Errors", ->
+        beforeEach ->
+          atom.config.set('notifications.allowPopups', 'Errors')
+
+        it "will only display error and fatal notifications", ->
+          expect(notificationContainer.childNodes.length).toBe 0
+
+          notification = atom.notifications.addSuccess('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addSuccess('A message', dismissable: true)
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addInfo('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addWarning('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addError('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addFatalError('A message')
+          expect(notificationContainer.childNodes.length).toBe 2
+          expect(notification.wasDisplayed()).toBe true
+
+      describe "when it is set to Dismissable", ->
+        beforeEach ->
+          atom.config.set('notifications.allowPopups', 'Dismissable')
+
+        it "will only display dismissable notifications", ->
+          expect(notificationContainer.childNodes.length).toBe 0
+
+          notification = atom.notifications.addSuccess('A message')
+          expect(notificationContainer.childNodes.length).toBe 0
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addSuccess('A dismissable message', dismissable: true)
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addInfo('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addWarning('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addError('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe false
+
+          notification = atom.notifications.addFatalError('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe false
+
+      describe "when it is set to anything else", ->
+        beforeEach ->
+          atom.config.set('notifications.allowPopups', 'anything else')
+
+        it "will display all notifications", ->
+          expect(notificationContainer.childNodes.length).toBe 0
+
+          notification = atom.notifications.addSuccess('A message')
+          expect(notificationContainer.childNodes.length).toBe 1
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addSuccess('A dismissable message', dismissable: true)
+          expect(notificationContainer.childNodes.length).toBe 2
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addInfo('A message')
+          expect(notificationContainer.childNodes.length).toBe 3
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addWarning('A message')
+          expect(notificationContainer.childNodes.length).toBe 4
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addError('A message')
+          expect(notificationContainer.childNodes.length).toBe 5
+          expect(notification.wasDisplayed()).toBe true
+
+          notification = atom.notifications.addFatalError('A message')
+          expect(notificationContainer.childNodes.length).toBe 6
+          expect(notification.wasDisplayed()).toBe true


### PR DESCRIPTION
### Description of the Change

Adds a setting to disable certain types of popups. Now that we have the notifications log users don't need to get a popup notification for every small thing.

The options are:

- All: Show all popups (default)
- Errors: Only show fatal and error popups
- Dismissable: Hide auto-hiding popups since they are usually only informational and don't require an action.
- None: (Ninja mode) This is for those times when a user just doesn't want to get distracted.

### Benefits

Give the user more control over when a distraction occurs.

### Possible Drawbacks

None
