### PR TITLE
Apply DOMPurify to marked output

### DIFF
--- a/lib/notification-element.coffee
+++ b/lib/notification-element.coffee
@@ -1,3 +1,4 @@
+DOMPurify = require 'dompurify'
 fs = require 'fs-plus'
 path = require 'path'
 marked = require 'marked'
@@ -87,7 +88,7 @@ class NotificationElement
     options = @model.getOptions()
 
     notificationContainer = @element.querySelector('.message')
-    notificationContainer.innerHTML = marked(@model.getMessage())
+    notificationContainer.innerHTML = DOMPurify.sanitize(marked(@model.getMessage()))
 
     if detail = @model.getDetail()
       addSplitLinesToContainer(@element.querySelector('.detail-content'), detail)

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "atom": ">0.50.0"
   },
   "dependencies": {
+    "dompurify": "^1.0.3",
     "fs-plus": "^3.0.0",
     "marked": "^0.3.6",
     "moment": "^2.19.3",

--- a/spec/notifications-spec.coffee
+++ b/spec/notifications-spec.coffee
@@ -106,6 +106,13 @@ describe "Notifications", ->
       notification = notificationContainer.childNodes[4]
       expect(notification.querySelector('.detail').textContent).toContain 'cats,ok'
 
+    it "renders the message as sanitized markdown", ->
+      atom.notifications.addInfo('test <b>html</b> <iframe>but sanitized</iframe>')
+      notification = notificationContainer.childNodes[0]
+      expect(notification.querySelector('.message').innerHTML).toContain(
+        'test <b>html</b> but sanitized'
+      )
+
     describe "when a dismissable notification is added", ->
       it "is removed when Notification::dismiss() is called", ->
         notification = atom.notifications.addSuccess('A message', dismissable: true)


### PR DESCRIPTION
See https://github.com/atom/notifications/issues/185 for the motivation behind this.

The DOMPurify API is super straightforward to use. I manually tested this in Atom by attempting to display a notification with an iframe (the iframe is stripped out now) and also added a spec.